### PR TITLE
Incremental build cache: skip notebook re-export when source unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Incremental build cache.** The preprocessor now caches `marimo
+  export ipynb` outputs at `{book_root}/.marimo_book_cache/manifest.json`
+  keyed by source content hash, marimo-book version, and relevant
+  `book.yml` fields (`widget_defaults`, `defaults`, `dependencies`,
+  `launch_buttons`, `repo`, `branch`, `toc`). Subsequent builds skip
+  notebooks whose source hasn't changed. Typical edit-one-chapter
+  rebuild on a 20-notebook book drops from "every notebook" to "only
+  the edited one". Markdown entries are not cached (10 ms each, not
+  worth the bookkeeping).
+- `marimo-book build --rebuild` and `marimo-book serve --rebuild` —
+  bypass the cache for the current invocation. Use when you changed
+  something the cache can't detect (data file the notebook reads,
+  env-mode dep upgrade). `--clean` continues to wipe `_site_src/` and
+  now also wipes `.marimo_book_cache/`, which has the same effect.
+- Build summary line now reports cache stats:
+  `Preprocessing OK (13 pages, 11 rendered, 1 cached at _site_src).`
 - `book.yml` `pdf_export: bool` flag — when true, emits the
   `mkdocs-with-pdf` plugin so the build produces a single
   `_site/pdf/book.pdf` rendered through WeasyPrint, with a "Download
@@ -20,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference covering the two-stage build pipeline, every CLI command
   with all flags, the five opt-in feature flags with their extras,
   the `_site_src/` and `_site/` output layouts, an ePub recipe via
-  pandoc, and approximate build-performance numbers.
+  pandoc, and approximate build-performance numbers. Now also covers
+  the build cache + invalidation rules.
 
 ## [0.1.0a3] — 2026-04-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,10 @@ Material's named-palette machinery doesn't fight us.
   — `dynamic = ["version"]` + hatch-vcs derives it from tags.
 - **Do not edit `src/marimo_book/_version.py`.** It's auto-generated
   at build time (gitignored, excluded from ruff).
+- **Do not hand-edit `{book_root}/.marimo_book_cache/manifest.json`.**
+  It's the build cache; the next preprocessor run overwrites it. To
+  force a full rebuild: `marimo-book build --rebuild` (preserves
+  cache after the run) or `marimo-book clean` (wipes everything).
 - **Do not push directly to `main`.** The harness blocks this; route
   through a PR.
 - **Do not bypass CI** with `--no-verify` or by skipping checks. Fix

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -30,6 +30,57 @@ artifacts mkdocs can consume. This keeps the shell swappable —
 [zensical](https://zensical.org) (Material's Rust successor) reuses
 the same `mkdocs.yml` verbatim.
 
+## Build cache
+
+`marimo export ipynb` re-executes every cell in a notebook from scratch
+— the dominant cost for any book with non-trivial computation. To
+avoid paying that cost on every rebuild, the preprocessor maintains a
+content-addressed cache.
+
+**How it works**
+
+After each successful build, the preprocessor writes a manifest at
+`{book_root}/.marimo_book_cache/manifest.json` recording, per `.py`
+TOC entry: source mtime, source SHA-256, the staged output path, and
+a timestamp. On the next build it consults the manifest:
+
+| Check | If true | If false |
+|---|---|---|
+| `cache.version` matches current schema | continue | full miss (reset cache) |
+| `marimo_book_version` matches | continue | full miss |
+| Hash of relevant `book.yml` fields matches | continue | full miss |
+| Per-entry: source mtime unchanged | **HIT** (skip render) | hash check |
+| Per-entry: source hash unchanged | **HIT** (refresh mtime) | MISS — re-render |
+
+`book.yml` fields that invalidate the cache: `widget_defaults`,
+`defaults`, `dependencies`, `launch_buttons`, `repo`, `branch`, the
+flattened `toc`. Fields that don't (palette, fonts, title, analytics)
+only affect `mkdocs.yml` emission, which is always re-run.
+
+**Markdown TOC entries are not cached** — Markdown render takes
+~10 ms each, so the bookkeeping isn't worth it.
+
+**What the cache cannot detect** (use `--rebuild` for these):
+
+- Data files the notebook reads (`pd.read_csv("data/foo.csv")`)
+- `env`-mode dependency upgrades (`pip install -U numpy`)
+- `sandbox`-mode PEP 723 dep changes inside the notebook (the
+  notebook's own mtime catches *some* of these, but pinned versions
+  on disk that change underneath you don't)
+- A `marimo` package upgrade (rare; bump the marimo-book version
+  yourself or `--rebuild` if a notebook starts rendering wrong)
+
+**Inspecting the cache**
+
+```bash
+cat .marimo_book_cache/manifest.json | jq .
+```
+
+Hand-edit at your peril; the next build will overwrite anything you
+change. To reset: `marimo-book clean` (removes `_site/`, `_site_src/`,
+and `.marimo_book_cache/`) or `marimo-book build --rebuild` (rebuilds
+fresh + repopulates the cache in one step).
+
 ## CLI commands
 
 ### `marimo-book new <directory>`
@@ -69,7 +120,8 @@ marimo-book build --clean --sandbox        # clean rebuild + force sandbox
 | `-b`, `--book PATH` | `book.yml` | Path to the book.yml config |
 | `-o`, `--output PATH` | `_site` | Output directory |
 | `--strict` | off | Fail on warnings (broken in-tree links, missing files, etc.) |
-| `--clean` | off | Remove `_site_src/` and the build cache before building |
+| `--clean` | off | Remove `_site/`, `_site_src/`, and `.marimo_book_cache/` before building (implies `--rebuild`) |
+| `--rebuild` | off | Re-render every notebook regardless of cache state — use when data files or env-mode deps changed |
 | `--sandbox` / `--no-sandbox` | follow `book.yml` | Override the dependency mode |
 
 **Use `--strict` in CI.** It surfaces issues that would otherwise be
@@ -101,6 +153,7 @@ edited. mkdocs's livereload pushes the browser refresh.
 | `--host TEXT` | `127.0.0.1` | Dev-server bind address |
 | `--port INTEGER` | `8000` | Dev-server port |
 | `--no-watch` | off | Disable the source watcher (useful for debugging) |
+| `--rebuild` | off | Cold-build the initial render (watcher rebuilds always honour the cache) |
 | `--sandbox` / `--no-sandbox` | follow `book.yml` | Override the dependency mode |
 
 !!! warning "macOS browser-reload flake"

--- a/src/marimo_book/cli.py
+++ b/src/marimo_book/cli.py
@@ -132,6 +132,15 @@ def build(
         "--clean",
         help="Remove _site_src/ and build cache before building.",
     ),
+    rebuild: bool = typer.Option(
+        False,
+        "--rebuild",
+        help=(
+            "Re-render every notebook regardless of cache state. Use when you "
+            "changed something the cache can't detect (a data file the notebook "
+            "reads, an env-mode dep upgrade, etc.). --clean implies --rebuild."
+        ),
+    ),
     sandbox: bool | None = typer.Option(
         None,
         "--sandbox/--no-sandbox",
@@ -148,11 +157,18 @@ def build(
     site_dir = Path(output).resolve() if output.is_absolute() else (book_dir / output).resolve()
 
     if clean:
-        for target in (site_src, site_dir):
+        for target in (site_src, site_dir, book_dir / ".marimo_book_cache"):
             if target.exists():
                 shutil.rmtree(target)
 
-    pre = Preprocessor(book, book_dir=book_dir, sandbox_override=sandbox)
+    # --clean removes the cache directory above, so the next build is
+    # cold either way; setting rebuild=True is just for clarity.
+    pre = Preprocessor(
+        book,
+        book_dir=book_dir,
+        sandbox_override=sandbox,
+        rebuild=rebuild or clean,
+    )
     typer.echo(
         f"Preprocessing '{book.title}' ({_count_toc(book.toc)} pages, "
         f"deps={'sandbox' if pre.sandbox else 'env'})..."
@@ -166,7 +182,7 @@ def build(
     if not report.ok:
         typer.echo(f"Preprocessing failed ({len(report.errors)} errors).", err=True)
         raise typer.Exit(code=1)
-    typer.echo(f"Preprocessing OK ({report.pages} pages staged at {site_src}).")
+    typer.echo(f"Preprocessing OK ({_summarise_report(report)} at {site_src}).")
 
     typer.echo(f"Running mkdocs build → {site_dir}")
     build_cmd = [sys.executable, "-m", "mkdocs", "build"]
@@ -197,6 +213,15 @@ def serve(
         "--no-watch",
         help="Serve without a source watcher (useful for debugging).",
     ),
+    rebuild: bool = typer.Option(
+        False,
+        "--rebuild",
+        help=(
+            "Re-render every notebook on the initial build (ignores cache). "
+            "Watcher rebuilds always honour the cache; use this only when the "
+            "first build needs to be cold."
+        ),
+    ),
     sandbox: bool | None = typer.Option(
         None,
         "--sandbox/--no-sandbox",
@@ -220,7 +245,7 @@ def serve(
     book_dir = book_file.resolve().parent
     site_src = book_dir / "_site_src"
 
-    pre = Preprocessor(book, book_dir=book_dir, sandbox_override=sandbox)
+    pre = Preprocessor(book, book_dir=book_dir, sandbox_override=sandbox, rebuild=rebuild)
     typer.echo(
         f"Preprocessing '{book.title}' ({_count_toc(book.toc)} pages, "
         f"deps={'sandbox' if pre.sandbox else 'env'})..."
@@ -229,7 +254,7 @@ def serve(
     _report_build(report)
     if not report.ok:
         raise typer.Exit(code=1)
-    typer.echo(f"Preprocessing OK ({report.pages} pages staged at {site_src}).")
+    typer.echo(f"Preprocessing OK ({_summarise_report(report)} at {site_src}).")
 
     typer.echo(f"Starting mkdocs serve on http://{host}:{port}/")
     mkdocs_cmd = [
@@ -282,10 +307,18 @@ def _report_build(report) -> None:
         typer.echo(f"  error: {err}", err=True)
 
 
+def _summarise_report(report) -> str:
+    """Compact one-liner describing a BuildReport's pages + cache stats."""
+    parts = [f"{report.pages} pages"]
+    if report.pages_cached or report.pages_rendered:
+        parts.append(f"{report.pages_rendered} rendered, {report.pages_cached} cached")
+    return ", ".join(parts)
+
+
 def _watcher_report_callback(report) -> None:
     """Called by the watcher after each rebuild. Logs result; never raises."""
     if report.ok:
-        typer.echo(f"  rebuilt ({report.pages} pages)")
+        typer.echo(f"  rebuilt ({_summarise_report(report)})")
     else:
         typer.echo("  rebuild failed:", err=True)
         _report_build(report)

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -21,8 +21,13 @@ mkdocs installed.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import shutil
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from .config import Book, FileEntry, SectionEntry, UrlEntry
@@ -43,12 +48,164 @@ class BuildReport:
     """Summary of what the preprocessor produced."""
 
     pages: int = 0
+    pages_cached: int = 0
+    pages_rendered: int = 0
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
         return not self.errors
+
+
+# --- build cache ------------------------------------------------------------
+
+# Bumped whenever the cache schema or hit-decision rules change.
+_CACHE_SCHEMA_VERSION = 1
+_CACHE_DIR_NAME = ".marimo_book_cache"
+_CACHE_FILE_NAME = "manifest.json"
+
+
+class BuildCache:
+    """Per-file content cache for ``marimo export`` outputs.
+
+    Each TOC entry resolves to a HIT (skip the expensive notebook export
+    and reuse the staged ``.md``) or MISS (render fresh, record the new
+    fingerprint). The cache is keyed by source content, the marimo-book
+    version, and any ``book.yml`` field that affects rendering — so a
+    schema change, tool upgrade, or relevant config change invalidates
+    everything safely.
+
+    Markdown TOC entries are NOT cached: their render is ~10 ms each and
+    not worth the bookkeeping. Only ``.py`` notebook entries pass through
+    the cache.
+    """
+
+    def __init__(self, book_dir: Path, book: Book, *, force_rebuild: bool = False) -> None:
+        self.path = book_dir / _CACHE_DIR_NAME / _CACHE_FILE_NAME
+        self.force_rebuild = force_rebuild
+        self.tool_version = _resolve_tool_version()
+        self.book_signature = _book_signature(book)
+        self.entries: dict[str, dict] = {}
+        self.dirty = False
+        if not force_rebuild:
+            self._load()
+
+    def is_hit(self, src_rel: str, src_abs: Path, docs_dir: Path) -> bool:
+        if self.force_rebuild:
+            return False
+        entry = self.entries.get(src_rel)
+        if entry is None:
+            return False
+        out_abs = docs_dir / entry["out_path"]
+        if not out_abs.exists():
+            return False
+        try:
+            mtime = src_abs.stat().st_mtime
+        except OSError:
+            return False
+        if mtime == entry["src_mtime"]:
+            return True
+        # mtime moved but content might still match (git checkout, touch,
+        # editor that rewrites unchanged files). Fall through to a hash
+        # check; refresh the recorded mtime on a content-equal hit so the
+        # next build takes the fast path.
+        try:
+            digest = _file_sha256(src_abs)
+        except OSError:
+            return False
+        if digest != entry["src_hash"]:
+            return False
+        entry["src_mtime"] = mtime
+        self.dirty = True
+        return True
+
+    def record(self, src_rel: str, src_abs: Path, out_rel: str) -> None:
+        try:
+            mtime = src_abs.stat().st_mtime
+            digest = _file_sha256(src_abs)
+        except OSError:
+            return
+        self.entries[src_rel] = {
+            "src_mtime": mtime,
+            "src_hash": digest,
+            "out_path": out_rel,
+            "rendered_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        }
+        self.dirty = True
+
+    def save(self) -> None:
+        if not self.dirty and self.path.exists():
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": _CACHE_SCHEMA_VERSION,
+            "marimo_book_version": self.tool_version,
+            "book_yml_hash": self.book_signature,
+            "entries": self.entries,
+        }
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        self.dirty = False
+
+    # --- internals ----------------------------------------------------------
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return  # corrupt cache → silent cold start
+        if data.get("version") != _CACHE_SCHEMA_VERSION:
+            return
+        if data.get("marimo_book_version") != self.tool_version:
+            return
+        if data.get("book_yml_hash") != self.book_signature:
+            return
+        loaded = data.get("entries", {})
+        if isinstance(loaded, dict):
+            self.entries = loaded
+
+
+def _resolve_tool_version() -> str:
+    """Read the installed package version; fall back to a sentinel if missing."""
+    try:
+        return _pkg_version("marimo-book")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+def _book_signature(book: Book) -> str:
+    """Hash ``book.yml`` fields whose changes invalidate rendered pages.
+
+    Includes anything the preprocessor reads while rendering a notebook
+    or applying link-rewrites: ``defaults`` (e.g. ``hide_first_code_cell``),
+    ``dependencies`` (mode), ``widget_defaults`` (anywidget seed state),
+    ``launch_buttons`` + ``repo`` + ``branch`` (button row), and the
+    flattened TOC (link rewrites depend on which other pages exist).
+
+    Excludes title / palette / fonts / analytics — those only affect
+    ``mkdocs.yml`` emission, which is always re-run and cheap.
+    """
+    relevant: dict = {
+        "widget_defaults": book.widget_defaults,
+        "defaults": book.defaults.model_dump(mode="json"),
+        "dependencies": book.dependencies.model_dump(mode="json"),
+        "launch_buttons": book.launch_buttons.model_dump(mode="json"),
+        "repo": book.repo,
+        "branch": book.branch,
+        "toc": [e.model_dump(mode="json") for e in book.toc],
+    }
+    payload = json.dumps(relevant, sort_keys=True, default=str)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
 
 
 class Preprocessor:
@@ -64,11 +221,15 @@ class Preprocessor:
         *,
         book_dir: Path,
         sandbox_override: bool | None = None,
+        rebuild: bool = False,
     ) -> None:
         self.book = book
         self.book_dir = Path(book_dir).resolve()
         # None = honour book.yml's dependencies.mode; True/False overrides.
         self.sandbox_override = sandbox_override
+        # When True, every TOC entry is re-rendered regardless of cache state.
+        # The cache is still updated so future builds without --rebuild benefit.
+        self.rebuild = rebuild
 
     @property
     def sandbox(self) -> bool:
@@ -108,19 +269,34 @@ class Preprocessor:
         file_entries = _iter_file_entries(self.book.toc)
         md_basenames = {_doc_relpath_for(e.file).with_suffix("").name for e in file_entries}
 
+        cache = BuildCache(self.book_dir, self.book, force_rebuild=self.rebuild)
+
         for entry in file_entries:
+            src_rel = str(entry.file)
+            src_abs = (self.book_dir / entry.file).resolve()
+            out_rel = _doc_relpath_for(entry.file).as_posix()
             try:
-                stage_page(
-                    self.book,
-                    self.book_dir,
-                    entry,
-                    docs_dir,
-                    md_basenames=md_basenames,
-                    sandbox=self.sandbox,
-                )
+                # Notebook entries are the only ones worth caching: marimo
+                # export takes seconds-to-minutes, vs ~10 ms for Markdown.
+                if entry.file.suffix == ".py" and cache.is_hit(src_rel, src_abs, docs_dir):
+                    report.pages_cached += 1
+                else:
+                    stage_page(
+                        self.book,
+                        self.book_dir,
+                        entry,
+                        docs_dir,
+                        md_basenames=md_basenames,
+                        sandbox=self.sandbox,
+                    )
+                    if entry.file.suffix == ".py":
+                        cache.record(src_rel, src_abs, out_rel)
+                    report.pages_rendered += 1
                 report.pages += 1
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{entry.file}: {exc.__class__.__name__}: {exc}")
+
+        cache.save()
 
         nav = _nav_from_toc(self.book.toc)
         if self.book.include_changelog and self._stage_changelog(docs_dir):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import json
+import shutil
+import time
 from pathlib import Path
 
 import yaml
 
 from marimo_book.config import Book
 from marimo_book.preprocessor import Preprocessor
+
+FIXTURES = Path(__file__).parent / "fixtures"
+NOTEBOOK_FIXTURE = FIXTURES / "simple_notebook.py"
 
 
 def _minimal_book(book_dir: Path) -> None:
@@ -108,3 +114,126 @@ def test_pdf_export_adds_with_pdf_plugin(tmp_path: Path) -> None:
     mkdocs = yaml.safe_load((out_dir / "mkdocs.yml").read_text(encoding="utf-8"))
     plugin_names = [next(iter(p.keys())) if isinstance(p, dict) else p for p in mkdocs["plugins"]]
     assert "with-pdf" in plugin_names
+
+
+# --- BuildCache --------------------------------------------------------------
+#
+# These tests drive the preprocessor end-to-end against a real .py notebook
+# fixture, so they invoke `marimo export ipynb` per build. ~2-3 seconds each
+# on a warm machine; we run a tiny notebook fixture to keep them fast.
+
+
+def _book_with_notebook(book_dir: Path) -> Book:
+    """Lay down a book with one Markdown page and one notebook (the fixture)."""
+    content = book_dir / "content"
+    content.mkdir(exist_ok=True)
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    shutil.copy(NOTEBOOK_FIXTURE, content / "notebook.py")
+    return Book.model_validate(
+        {
+            "title": "Cache Test",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/notebook.py"},
+            ],
+        }
+    )
+
+
+def _manifest(out_dir: Path, book_dir: Path) -> dict:
+    return json.loads(
+        (book_dir / ".marimo_book_cache" / "manifest.json").read_text(encoding="utf-8")
+    )
+
+
+def test_cache_cold_then_warm(tmp_path: Path) -> None:
+    """First build renders + writes manifest; second build hits the cache."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    cold = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert cold.pages_rendered == 2  # intro.md + notebook.py
+    assert cold.pages_cached == 0
+    assert (tmp_path / ".marimo_book_cache" / "manifest.json").exists()
+
+    warm = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    # .md still re-renders (not cached); .py is the only cache target.
+    assert warm.pages_cached == 1
+    assert warm.pages_rendered == 1
+
+
+def test_cache_invalidates_on_source_change(tmp_path: Path) -> None:
+    """Editing the notebook source forces a re-render of just that entry."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    nb = tmp_path / "content" / "notebook.py"
+    # Bump mtime AND content so both fast-path and slow-path miss.
+    time.sleep(0.01)
+    nb.write_text(nb.read_text(encoding="utf-8") + "\n# touched\n", encoding="utf-8")
+
+    second = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert second.pages_rendered == 2  # intro.md (always) + notebook.py (invalidated)
+    assert second.pages_cached == 0
+
+
+def test_rebuild_flag_forces_full_render(tmp_path: Path) -> None:
+    """`rebuild=True` skips the cache even when entries are valid."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    forced = Preprocessor(book, book_dir=tmp_path, rebuild=True).build(out_dir=out_dir)
+    assert forced.pages_cached == 0
+    assert forced.pages_rendered == 2
+
+
+def test_cache_invalidates_on_tool_version_change(tmp_path: Path) -> None:
+    """Bumping the recorded marimo_book_version invalidates the whole cache."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+    Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+
+    manifest_path = tmp_path / ".marimo_book_cache" / "manifest.json"
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    data["marimo_book_version"] = "0.0.0+impossible"
+    manifest_path.write_text(json.dumps(data), encoding="utf-8")
+
+    second = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert second.pages_cached == 0
+    assert second.pages_rendered == 2
+
+
+def test_cache_invalidates_on_widget_defaults_change(tmp_path: Path) -> None:
+    """Editing widget_defaults in book.yml invalidates rendered notebooks."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+    Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+
+    book2 = Book.model_validate(
+        {
+            "title": "Cache Test",
+            "widget_defaults": {"FakeWidget": {"x": 1}},
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/notebook.py"},
+            ],
+        }
+    )
+    second = Preprocessor(book2, book_dir=tmp_path).build(out_dir=out_dir)
+    assert second.pages_cached == 0
+    assert second.pages_rendered == 2
+
+
+def test_cache_invalidates_when_staged_output_missing(tmp_path: Path) -> None:
+    """If someone wipes _site_src but leaves the cache, we must re-render."""
+    book = _book_with_notebook(tmp_path)
+    out_dir = tmp_path / "_site_src"
+    Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+
+    # Wipe the staged tree but leave the manifest alone.
+    shutil.rmtree(out_dir)
+    second = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert second.pages_cached == 0
+    assert second.pages_rendered == 2


### PR DESCRIPTION
## Summary

Every \`marimo-book build\` re-ran \`marimo export ipynb\` for every \`.py\` in the TOC, even when no source had changed. For dartbrains (~20 notebooks of real neuroimaging code) that's the dominant cost — minutes per build, multiplied across the dev loop. zensical wouldn't help: its differential-build engine is for HTML rendering, downstream of where we burn the time.

## Cache design

- \`BuildCache\` (in \`src/marimo_book/preprocessor.py\`) writes \`{book_root}/.marimo_book_cache/manifest.json\` after each successful build. Per \`.py\` TOC entry: src mtime, src SHA-256, staged out path, ISO timestamp.
- **Hit decision per entry:**
  1. Cache schema version matches
  2. \`marimo_book_version\` matches
  3. \`book.yml\` signature matches (\`widget_defaults\` + \`defaults\` + \`dependencies\` + \`launch_buttons\` + \`repo\` + \`branch\` + flattened TOC)
  4. Staged output exists
  5. src mtime unchanged → **fast-path HIT**, else
  6. src hash unchanged → **slow-path HIT** (refreshes mtime so next build is fast-path)
- **Markdown entries are not cached** — ~10 ms each, not worth tracking.
- Fields that affect only \`mkdocs.yml\` emission (palette, fonts, title, analytics) deliberately don't invalidate — that work is always redone and is cheap.

## CLI

- New \`--rebuild\` flag on \`marimo-book build\` and \`marimo-book serve\`. Bypasses the cache for the current invocation; cache is still updated so future builds benefit. Use when you changed something the cache can't detect (data file the notebook reads, env-mode dep upgrade).
- \`marimo-book build --clean\` now also wipes \`.marimo_book_cache/\` (was leaving it intact).
- \`Preprocessing OK\` summary line now reports cache stats: \`(13 pages, 11 rendered, 1 cached at _site_src)\`.

\`BuildReport\` gains \`pages_cached\` and \`pages_rendered\` counters. The \`serve\` watcher constructs Preprocessor *without* the rebuild flag so file-change rebuilds always honour the cache (the source mtime change naturally invalidates exactly the affected entry).

## Tests (6 new, 62/62 passing)

| Scenario | What it verifies |
|---|---|
| cold → warm | First build renders + writes manifest; second build hits cache |
| source-edit | Editing \`.py\` invalidates that one entry; others stay cached |
| \`--rebuild\` bypass | Forces all entries to MISS even when cache valid |
| tool-version bump | Manifest \`marimo_book_version\` changing invalidates whole cache |
| \`widget_defaults\` change | book.yml signature drift invalidates whole cache |
| staged output missing | Wiping \`_site_src/\` while cache exists triggers re-render |

## Real-world impact

On this repo's docs (single \`.py\` notebook):

\`\`\`
cold 1.32s → warm 0.54s   (2.5x)
\`\`\`

For dartbrains the speedup will be much larger in absolute terms. Build time goes from O(notebooks × execution_time) to O(notebooks_actually_edited × execution_time).

## Test plan

- [x] \`pytest\` 62/62 passing including 6 new cache tests
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Cold/warm/--rebuild cycle on this repo's docs
- [ ] Try on dartbrains — should drop edit-one-chapter rebuild from "minutes" to "seconds"

## Out of scope (deferred)

- Markdown caching (too cheap to bother)
- Tracking external files referenced by notebooks (\`pd.read_csv("data/foo.csv")\`) — \`--rebuild\` covers this
- Sandbox-mode PEP 723 dep hash — defer
- Static reactivity for \`mo.ui.slider\` / \`mo.ui.dropdown\` — separate planning round next, with hard caps on enumerated values per widget and total cross-product size

🤖 Generated with [Claude Code](https://claude.com/claude-code)