### PR TITLE
Static-reactivity foundation: config + AST scanner + cap preview (1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — static reactivity foundation (1/2)
+
+- `book.yml` `precompute` block (off by default) — opt-in static
+  reactivity for discrete marimo UI widgets. Five fields:
+  `enabled`, `max_values_per_widget` (default 50),
+  `max_combinations_per_page` (200), `max_seconds_per_page` (60),
+  `max_bytes_per_page` (10 MB), `exclude_pages` ([]).
+- AST scanner (`src/marimo_book/transforms/precompute.py`) that finds
+  precompute candidates without executing the notebook. Recognises:
+  `mo.ui.slider(steps=[...])`, `mo.ui.slider(start, stop, step=N)`
+  (or 3 positional args), `mo.ui.dropdown(options=[...])`,
+  `mo.ui.dropdown(options={...})`, `mo.ui.switch()`, `mo.ui.checkbox()`,
+  `mo.ui.radio(options=[...])`. Continuous sliders without an explicit
+  step are deliberately skipped (render static). Non-literal arguments
+  (`mo.ui.dropdown(options=opts)`) are skipped — value sets must be
+  statically extractable.
+- Preprocessor preview pass: when `precompute.enabled: true`, every
+  `.py` page is scanned, count caps are applied, and over-cap widgets
+  are recorded as `BuildReport.warnings` ("rendered static") with the
+  page + widget name + which cap was hit. `BuildReport` gains
+  `widgets_precomputed` / `widgets_skipped` counters.
+- Build cache `_book_signature` now includes the `precompute` block,
+  so toggling the flag invalidates rendered notebooks correctly.
+
+This is the foundation only — the actual per-value re-export pipeline
++ client-side JS swap shim ship in the next PR. Until that lands,
+`widgets_precomputed` is a *would-precompute* count: useful for tuning
+caps before paying for execution.
+
 ## [0.1.0a4] — 2026-04-25
 
 Build-cache + PDF + docs release. Cuts repeat-build time on books

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ install it (the docs job needs every extra the docs site uses).
 | `check_external_links: true` | `htmlproofer` validates external URLs at build (slow; CI-only) | `marimo-book[linkcheck]` |
 | `include_changelog: true` | Preprocessor copies `CHANGELOG.md` from book root (or its parent) into the staged tree and appends a "Changelog" entry to the nav | None |
 | `pdf_export: true` | `mkdocs-with-pdf` renders the whole book to `_site/pdf/book.pdf` via WeasyPrint and adds a "Download PDF" link to the footer | `marimo-book[pdf]` (same cairo/pango system deps as `[social]`) |
+| `precompute.enabled: true` | Detects discrete `mo.ui.*` widgets, applies caps, and (when complete — see PR #7) re-exports per value to ship a JSON lookup table that powers client-side widget interactivity. Foundation in PR #6 ships scanner + caps; execution + JS shim land in PR #7. | None |
 
-All five are off by default in `marimo-book new` scaffolds.
+All six are off by default in `marimo-book new` scaffolds.
 
 ## Theme + CSS
 

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -80,6 +80,51 @@ class Bibliography(BaseModel):
     files: list[Path] = Field(default_factory=list)
 
 
+class Precompute(BaseModel):
+    """Static-reactivity opt-in for discrete marimo UI widgets.
+
+    When ``enabled`` is true, the preprocessor scans each ``.py`` page
+    for widget calls whose value set is statically determinable
+    (``mo.ui.slider`` with ``steps=[...]`` or explicit ``step=N``,
+    ``mo.ui.dropdown``, ``mo.ui.switch``, ``mo.ui.radio``). For each
+    candidate it re-runs ``marimo export`` once per value (or per
+    cartesian combination across widgets sharing a downstream subgraph)
+    and embeds a JSON lookup table in the rendered page. A small JS
+    shim swaps the visible output as the reader interacts with the
+    widget — real-feeling interactivity without a Python kernel.
+
+    Caps protect against pathological cases. Widgets / pages that
+    exceed any cap are gracefully skipped (rendered static, with a
+    ``BuildReport.warnings`` entry); the build does not fail unless
+    you pass ``--strict``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+
+    # Hard count caps — checked before any execution starts. Cheap.
+    max_values_per_widget: int = Field(default=50, ge=1)
+    max_combinations_per_page: int = Field(default=200, ge=1)
+
+    # Wall-clock budget per page — checked after the first re-export
+    # completes. If `first_export_seconds * remaining_combinations` would
+    # exceed this, the rest of the page's precompute is aborted and the
+    # page renders static at default values. The first export is *always*
+    # paid (we need it as the static fallback anyway), so very small
+    # budgets just mean "skip precompute, render static".
+    max_seconds_per_page: int = Field(default=60, ge=1)
+
+    # Bundle-size cap — checked after each combination's output is
+    # captured. Aborts further precompute when total embedded bytes for
+    # the page would exceed.
+    max_bytes_per_page: int = Field(default=10 * 1024 * 1024, ge=1024)
+
+    # Per-page opt-out. Pages listed here render every widget as static
+    # even when `enabled: true`.
+    exclude_pages: list[str] = Field(default_factory=list)
+
+
 class Analytics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -267,6 +312,15 @@ class Book(BaseModel):
     # (~30 s for ~50 pages); turn off in ``serve`` and on in CI / for
     # release builds. Requires: ``pip install marimo-book[pdf]``.
     pdf_export: bool = False
+
+    # Opt-in static reactivity for marimo UI elements. When enabled, the
+    # preprocessor scans each ``.py`` page for discrete widget candidates
+    # (``mo.ui.slider`` with explicit ``steps=[]`` or ``step=N``,
+    # ``mo.ui.dropdown``, ``mo.ui.switch``, ``mo.ui.radio``) and re-runs
+    # ``marimo export`` once per value, embedding the results as a
+    # client-side lookup table. A small JS shim binds the widget input to
+    # swap the visible output without a Python kernel.
+    precompute: Precompute = Field(default_factory=lambda: Precompute())
 
     # render defaults
     defaults: Defaults = Field(default_factory=Defaults)

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -35,6 +35,12 @@ from .launch_buttons import render_button_row
 from .shell import _nav_from_toc, emit_mkdocs_yml
 from .transforms.link_rewrites import apply_link_rewrites
 from .transforms.marimo_export import cells_to_markdown, export_notebook
+from .transforms.precompute import (
+    WidgetCandidate,
+    estimate_combinations,
+    page_excluded,
+    scan_widgets,
+)
 
 # Directories and glob patterns of assets we copy verbatim when present.
 _ASSET_DIRS: tuple[str, ...] = ("images", "Code", "data")
@@ -50,6 +56,10 @@ class BuildReport:
     pages: int = 0
     pages_cached: int = 0
     pages_rendered: int = 0
+    # Counts of widgets that passed cap checks and would precompute
+    # (Phase 2 only previews; Phase 3 wires the actual execution).
+    widgets_precomputed: int = 0
+    widgets_skipped: int = 0
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
@@ -192,6 +202,7 @@ def _book_signature(book: Book) -> str:
         "defaults": book.defaults.model_dump(mode="json"),
         "dependencies": book.dependencies.model_dump(mode="json"),
         "launch_buttons": book.launch_buttons.model_dump(mode="json"),
+        "precompute": book.precompute.model_dump(mode="json"),
         "repo": book.repo,
         "branch": book.branch,
         "toc": [e.model_dump(mode="json") for e in book.toc],
@@ -293,6 +304,12 @@ class Preprocessor:
                         cache.record(src_rel, src_abs, out_rel)
                     report.pages_rendered += 1
                 report.pages += 1
+
+                # Static-reactivity preview: scan widgets + apply count
+                # caps so authors see the inventory now. Actual execution
+                # ships in a follow-up PR (Phase 3).
+                if entry.file.suffix == ".py" and self.book.precompute.enabled:
+                    self._preview_precompute(entry, src_abs, report)
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{entry.file}: {exc.__class__.__name__}: {exc}")
 
@@ -324,6 +341,56 @@ class Preprocessor:
             if dst.exists():
                 shutil.rmtree(dst)
             shutil.copytree(src, dst)
+
+    def _preview_precompute(self, entry: FileEntry, src_abs: Path, report: BuildReport) -> None:
+        """Scan a notebook for widget candidates + apply count caps.
+
+        Phase 2 of the static-reactivity rollout: we report the inventory
+        and surface cap-violation warnings, but do NOT actually re-export
+        the notebook per value yet (that lands in a follow-up PR). This
+        lets authors enable ``precompute.enabled: true`` early and tune
+        their caps without waiting for the full pipeline.
+
+        The function is a no-op for pages listed in ``exclude_pages``.
+        Per-widget cap violations downgrade the widget to "skipped"; the
+        page-wide cap collapses every candidate on the page to "skipped".
+        """
+        cfg = self.book.precompute
+        if page_excluded(entry.file, cfg.exclude_pages):
+            return
+
+        try:
+            source = src_abs.read_text(encoding="utf-8")
+        except OSError:
+            return
+        candidates = scan_widgets(source)
+        if not candidates:
+            return
+
+        kept: list[WidgetCandidate] = []
+        for c in candidates:
+            if len(c.values) > cfg.max_values_per_widget:
+                report.warnings.append(
+                    f"{entry.file}:{c.line} {c.var_name} "
+                    f"({len(c.values)} values) exceeds "
+                    f"max_values_per_widget ({cfg.max_values_per_widget}); "
+                    f"rendered static."
+                )
+                report.widgets_skipped += 1
+                continue
+            kept.append(c)
+
+        combos = estimate_combinations(kept)
+        if combos > cfg.max_combinations_per_page:
+            report.warnings.append(
+                f"{entry.file}: {len(kept)} widgets generate {combos} "
+                f"combinations, exceeding max_combinations_per_page "
+                f"({cfg.max_combinations_per_page}); page rendered static."
+            )
+            report.widgets_skipped += len(kept)
+            return
+
+        report.widgets_precomputed += len(kept)
 
     def _stage_changelog(self, docs_dir: Path) -> bool:
         """Copy ``CHANGELOG.md`` into the staged tree.

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -1,0 +1,264 @@
+"""Detect and precompute discrete marimo UI widgets for static reactivity.
+
+The preprocessor calls :func:`scan_widgets` on each marimo notebook's source
+to find widget calls whose value set is statically determinable. Candidate
+widgets are then driven by ``Preprocessor`` through a per-value re-export
+loop (Path X — see the plan); the resulting outputs become a JSON lookup
+table embedded in the page, and ``assets/marimo_book.js`` swaps them on
+client-side interaction.
+
+This module is **detection + classification only**. The actual re-export
+orchestration lives in :mod:`marimo_book.preprocessor` so it can share the
+build cache and report counters.
+
+Design summary:
+
+- The widget IS the annotation. Authors write normal marimo code.
+- ``mo.ui.slider`` with ``steps=[...]`` or explicit ``step=N`` is a
+  candidate. Bare ``mo.ui.slider(0, 10)`` (no step) is treated as
+  continuous and rendered static.
+- ``mo.ui.dropdown`` / ``switch`` / ``checkbox`` / ``radio`` are
+  always discrete; always candidates when precompute is enabled.
+- Widgets created via non-literal calls (``make_slider(low, high)``)
+  are skipped silently — the value set isn't statically extractable.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# marimo widget call patterns we recognise. Keys are the dotted attribute
+# path; values name the discovery strategy used to extract value sets.
+_WIDGET_KIND_BY_ATTR: dict[str, str] = {
+    "mo.ui.slider": "slider",
+    "mo.ui.dropdown": "dropdown",
+    "mo.ui.switch": "switch",
+    "mo.ui.checkbox": "switch",
+    "mo.ui.radio": "radio",
+}
+
+
+@dataclass(frozen=True)
+class WidgetCandidate:
+    """A statically-discovered precompute candidate.
+
+    ``var_name`` is the assignment target (``slider`` in
+    ``slider = mo.ui.slider(...)``). ``values`` is the discovered value
+    list, in source order. ``default`` is the value the widget will show
+    on first paint (matches marimo's own default-resolution rule:
+    explicit ``value=`` kwarg if present, else the first value, else
+    None).
+    """
+
+    var_name: str
+    kind: str  # "slider" | "dropdown" | "switch" | "radio"
+    values: list[Any]
+    default: Any
+    line: int  # 1-indexed source line for error messages
+
+
+def scan_widgets(source: str) -> list[WidgetCandidate]:
+    """Walk a marimo notebook's source and return precompute candidates.
+
+    Skips silently (returns no candidate) for:
+
+    - Continuous-slider patterns (``mo.ui.slider(start, stop)`` with no step)
+    - Widget calls assigned to non-name targets (``foo[0] = mo.ui.slider(...)``)
+    - Widget calls inside complex expressions (``[mo.ui.slider(...) for ...]``)
+    - Widgets with non-literal arguments (``mo.ui.dropdown(options=options)``)
+
+    All of those still RENDER (as static), they just don't precompute.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    out: list[WidgetCandidate] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        # Only handle the simple case ``name = mo.ui.X(...)``. Tuple
+        # unpacking, subscripts, attribute assignment etc. are out of scope.
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+
+        attr_path = _dotted_attr(node.value.func)
+        if attr_path is None:
+            continue
+        kind = _WIDGET_KIND_BY_ATTR.get(attr_path)
+        if kind is None:
+            continue
+
+        candidate = _build_candidate(
+            var_name=node.targets[0].id,
+            kind=kind,
+            call=node.value,
+            line=node.lineno,
+        )
+        if candidate is not None:
+            out.append(candidate)
+    return out
+
+
+# --- internals --------------------------------------------------------------
+
+
+def _dotted_attr(node: ast.AST) -> str | None:
+    """Return ``"a.b.c"`` for an attribute/name chain, else None."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _build_candidate(
+    *, var_name: str, kind: str, call: ast.Call, line: int
+) -> WidgetCandidate | None:
+    """Dispatch to the per-kind value extractor; return a Candidate on success."""
+    kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+    if kind == "slider":
+        values = _slider_values(call.args, kwargs)
+    elif kind == "dropdown":
+        values = _dropdown_values(kwargs)
+    elif kind == "switch":
+        values = [True, False]
+    elif kind == "radio":
+        values = _list_kwarg(kwargs, "options")
+    else:  # pragma: no cover — _WIDGET_KIND_BY_ATTR guards this
+        return None
+
+    if values is None:
+        return None
+    default = _literal_or_none(kwargs.get("value")) if "value" in kwargs else _safe_first(values)
+    return WidgetCandidate(var_name=var_name, kind=kind, values=values, default=default, line=line)
+
+
+def _slider_values(args: list[ast.expr], kwargs: dict[str, ast.expr]) -> list[Any] | None:
+    """Slider extraction follows the user-decided rule: opt out continuous
+    sliders unless an explicit grid is specified.
+
+    Recognised forms (all with literal numeric arguments):
+
+    - ``mo.ui.slider(steps=[a, b, c, ...])``   — explicit list
+    - ``mo.ui.slider(start, stop, step=N)``    — explicit step kwarg
+    - ``mo.ui.slider(start, stop, step)``      — three positional args
+
+    Everything else (``mo.ui.slider(start, stop)`` with no step) is
+    continuous and skipped.
+    """
+    if "steps" in kwargs:
+        return _list_kwarg(kwargs, "steps")
+
+    # Need start, stop, AND step (positional or kwarg).
+    if len(args) >= 3:
+        start, stop, step = (
+            _literal_or_none(args[0]),
+            _literal_or_none(args[1]),
+            _literal_or_none(args[2]),
+        )
+    elif len(args) == 2 and "step" in kwargs:
+        start, stop, step = (
+            _literal_or_none(args[0]),
+            _literal_or_none(args[1]),
+            _literal_or_none(kwargs["step"]),
+        )
+    else:
+        return None  # continuous — opt out
+
+    if not all(isinstance(v, (int, float)) for v in (start, stop, step)):
+        return None
+    if step == 0:
+        return None  # malformed
+
+    # Inclusive of stop, like marimo's slider semantics.
+    return _arange_inclusive(start, stop, step)
+
+
+def _arange_inclusive(start: float, stop: float, step: float) -> list[Any]:
+    """Numpy-like arange but inclusive of stop, with int coercion when safe."""
+    out: list[Any] = []
+    n = 0
+    while True:
+        v = start + n * step
+        # Floating-point drift guard: stop iterating once we're past stop
+        # by more than half a step in the direction of travel.
+        if step > 0 and v > stop + step * 0.5:
+            break
+        if step < 0 and v < stop + step * 0.5:
+            break
+        out.append(int(v) if float(v).is_integer() else round(v, 10))
+        n += 1
+        if n > 10_000:  # safety: never enumerate runaway grids
+            break
+    return out
+
+
+def _dropdown_values(kwargs: dict[str, ast.expr]) -> list[Any] | None:
+    """Dropdown supports ``options=[...]`` or ``options={k: v, ...}``."""
+    raw = kwargs.get("options")
+    if raw is None:
+        return None
+    if isinstance(raw, ast.List):
+        out = [_literal_or_none(e) for e in raw.elts]
+        zipped = zip(out, raw.elts, strict=True)
+        return out if all(o is not None or _is_none_literal(e) for o, e in zipped) else None
+    if isinstance(raw, ast.Dict):
+        keys = [_literal_or_none(k) for k in raw.keys if k is not None]
+        return keys if all(k is not None for k in keys) else None
+    return None
+
+
+def _list_kwarg(kwargs: dict[str, ast.expr], name: str) -> list[Any] | None:
+    """Extract a list-literal kwarg as a Python list, or None if non-literal."""
+    raw = kwargs.get(name)
+    if raw is None or not isinstance(raw, ast.List):
+        return None
+    out = [_literal_or_none(e) for e in raw.elts]
+    if any(o is None and not _is_none_literal(e) for o, e in zip(out, raw.elts, strict=True)):
+        return None
+    return out
+
+
+def _literal_or_none(node: ast.expr | None) -> Any:
+    """Return the Python value of a literal AST node, or None for non-literals."""
+    if node is None:
+        return None
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, SyntaxError):
+        return None
+
+
+def _is_none_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _safe_first(values: list[Any]) -> Any:
+    return values[0] if values else None
+
+
+# --- helpers used by the preprocessor for cap enforcement -------------------
+
+
+def estimate_combinations(candidates: list[WidgetCandidate]) -> int:
+    """Cartesian product size across candidates. Used for cap checks."""
+    n = 1
+    for c in candidates:
+        n *= max(1, len(c.values))
+    return n
+
+
+def page_excluded(book_relative_path: Path | str, exclude_pages: list[str]) -> bool:
+    """True iff the book-relative path matches one of ``exclude_pages``."""
+    needle = str(book_relative_path).replace("\\", "/")
+    return any(needle == ex.replace("\\", "/") for ex in exclude_pages)

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -1,0 +1,270 @@
+"""Tests for the static-reactivity widget detection (Phase 1).
+
+These cover the AST scanner only — no actual notebook execution. The
+re-export + lookup-table pipeline has its own end-to-end tests once
+Phase 3 lands.
+"""
+
+from __future__ import annotations
+
+from marimo_book.transforms.precompute import (
+    WidgetCandidate,
+    estimate_combinations,
+    page_excluded,
+    scan_widgets,
+)
+
+
+def _scan(src: str) -> list[WidgetCandidate]:
+    return scan_widgets(src)
+
+
+# --- slider ----------------------------------------------------------------
+
+
+def test_slider_with_steps_kwarg() -> None:
+    cands = _scan("slider = mo.ui.slider(steps=[0, 1, 5, 10])")
+    assert len(cands) == 1
+    c = cands[0]
+    assert c.var_name == "slider" and c.kind == "slider"
+    assert c.values == [0, 1, 5, 10]
+    assert c.default == 0
+
+
+def test_slider_with_explicit_step_kwarg() -> None:
+    cands = _scan("s = mo.ui.slider(0, 10, step=2)")
+    assert len(cands) == 1
+    assert cands[0].values == [0, 2, 4, 6, 8, 10]
+
+
+def test_slider_with_three_positional_args() -> None:
+    cands = _scan("s = mo.ui.slider(0, 4, 1)")
+    assert len(cands) == 1
+    assert cands[0].values == [0, 1, 2, 3, 4]
+
+
+def test_slider_continuous_no_step_is_skipped() -> None:
+    """The user's rule: opt out continuous sliders unless an explicit grid."""
+    assert _scan("s = mo.ui.slider(0, 10)") == []
+
+
+def test_slider_with_float_step() -> None:
+    cands = _scan("s = mo.ui.slider(0.0, 1.0, step=0.25)")
+    assert len(cands) == 1
+    assert cands[0].values == [0.0, 0.25, 0.5, 0.75, 1.0]
+
+
+def test_slider_value_kwarg_sets_default() -> None:
+    cands = _scan("s = mo.ui.slider(steps=[1, 2, 3], value=2)")
+    assert cands[0].default == 2
+
+
+def test_slider_non_literal_args_skipped() -> None:
+    assert _scan("s = mo.ui.slider(low, high, step=1)") == []
+    assert _scan("s = mo.ui.slider(steps=values)") == []
+
+
+def test_slider_zero_step_skipped() -> None:
+    assert _scan("s = mo.ui.slider(0, 10, step=0)") == []
+
+
+# --- dropdown --------------------------------------------------------------
+
+
+def test_dropdown_with_list_options() -> None:
+    cands = _scan('d = mo.ui.dropdown(options=["a", "b", "c"])')
+    assert len(cands) == 1
+    assert cands[0].kind == "dropdown" and cands[0].values == ["a", "b", "c"]
+    assert cands[0].default == "a"
+
+
+def test_dropdown_with_dict_options_uses_keys() -> None:
+    cands = _scan('d = mo.ui.dropdown(options={"x": 1, "y": 2})')
+    assert cands[0].values == ["x", "y"]
+
+
+def test_dropdown_non_literal_options_skipped() -> None:
+    assert _scan("d = mo.ui.dropdown(options=opts)") == []
+
+
+# --- switch / checkbox ----------------------------------------------------
+
+
+def test_switch_always_two_values() -> None:
+    cands = _scan("s = mo.ui.switch()")
+    assert cands[0].values == [True, False]
+
+
+def test_checkbox_normalises_to_switch_kind() -> None:
+    cands = _scan("c = mo.ui.checkbox()")
+    assert cands[0].kind == "switch" and cands[0].values == [True, False]
+
+
+# --- radio ----------------------------------------------------------------
+
+
+def test_radio_with_list_options() -> None:
+    cands = _scan('r = mo.ui.radio(options=["yes", "no"])')
+    assert cands[0].kind == "radio" and cands[0].values == ["yes", "no"]
+
+
+# --- skip cases -----------------------------------------------------------
+
+
+def test_non_widget_calls_ignored() -> None:
+    assert _scan("x = mo.md('hi')") == []
+    assert _scan("y = pd.DataFrame()") == []
+    assert _scan("z = list(range(10))") == []
+
+
+def test_unsupported_widget_kinds_ignored() -> None:
+    """range_slider deferred to v2; not a candidate yet."""
+    assert _scan("r = mo.ui.range_slider(0, 10, step=1)") == []
+    assert _scan("t = mo.ui.text(value='hi')") == []
+
+
+def test_assignment_to_subscript_ignored() -> None:
+    assert _scan("config['slider'] = mo.ui.slider(steps=[0, 1])") == []
+
+
+def test_widget_inside_complex_expression_ignored() -> None:
+    assert _scan("widgets = [mo.ui.slider(steps=[0, 1])]") == []
+
+
+def test_syntax_error_returns_empty_not_raise() -> None:
+    assert _scan("def broken(:") == []
+
+
+# --- multiple widgets per page --------------------------------------------
+
+
+def test_multiple_widgets_in_one_source() -> None:
+    src = """
+slider = mo.ui.slider(steps=[1, 2])
+dropdown = mo.ui.dropdown(options=["a", "b", "c"])
+switch = mo.ui.switch()
+"""
+    cands = _scan(src)
+    kinds = sorted(c.kind for c in cands)
+    assert kinds == ["dropdown", "slider", "switch"]
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def test_estimate_combinations_is_cartesian_product() -> None:
+    a = WidgetCandidate("a", "slider", [1, 2], 1, 1)
+    b = WidgetCandidate("b", "dropdown", ["x", "y", "z"], "x", 2)
+    assert estimate_combinations([a, b]) == 6
+    assert estimate_combinations([]) == 1
+
+
+def test_page_excluded_matches_normalised_path() -> None:
+    assert page_excluded("content/heavy.py", ["content/heavy.py"]) is True
+    assert page_excluded("content/heavy.py", ["content/light.py"]) is False
+    assert page_excluded("content\\heavy.py", ["content/heavy.py"]) is True
+
+
+# --- preview integration (Phase 2) ----------------------------------------
+#
+# These cover the inventory + cap-checking layer the preprocessor adds when
+# `precompute.enabled: true`. They drive the full Preprocessor.build() so they
+# share the marimo-export plumbing (1-2 s each).
+
+from pathlib import Path  # noqa: E402
+
+from marimo_book.config import Book  # noqa: E402
+from marimo_book.preprocessor import Preprocessor  # noqa: E402
+
+
+def _book_with_widget_notebook(book_dir: Path, *, source: str) -> Book:
+    """Lay down a single-notebook book whose .py contains the given source."""
+    content = book_dir / "content"
+    content.mkdir(exist_ok=True)
+    nb = content / "demo.py"
+    nb.write_text(
+        "import marimo\n"
+        "\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n"
+        "\n"
+        "@app.cell\n"
+        "def __():\n"
+        "    import marimo as mo\n"
+        "    return mo,\n"
+        "\n"
+        "@app.cell\n"
+        f"def __(mo):\n"
+        f"    {source}\n"
+        "    return\n"
+        "\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    return Book.model_validate({"title": "Test", "toc": [{"file": "content/demo.py"}]})
+
+
+def _enable_precompute(book: Book, **overrides) -> Book:
+    """Return a copy of `book` with precompute enabled + overrides applied."""
+    payload = book.model_dump(mode="json")
+    payload["precompute"] = {"enabled": True, **overrides}
+    return Book.model_validate(payload)
+
+
+def test_preview_counts_widgets_when_enabled(tmp_path: Path) -> None:
+    book = _book_with_widget_notebook(tmp_path, source="slider = mo.ui.slider(steps=[0, 1, 5, 10])")
+    book = _enable_precompute(book)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 1
+    assert report.widgets_skipped == 0
+
+
+def test_preview_disabled_by_default(tmp_path: Path) -> None:
+    book = _book_with_widget_notebook(tmp_path, source="slider = mo.ui.slider(steps=[0, 1, 5, 10])")
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 0
+
+
+def test_preview_widget_over_max_values_skipped_with_warning(tmp_path: Path) -> None:
+    big = ", ".join(str(i) for i in range(60))
+    book = _book_with_widget_notebook(tmp_path, source=f"slider = mo.ui.slider(steps=[{big}])")
+    book = _enable_precompute(book, max_values_per_widget=50)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 1
+    assert any("max_values_per_widget" in w for w in report.warnings)
+
+
+def test_preview_page_over_max_combinations_skips_all(tmp_path: Path) -> None:
+    # 11 × 11 × 11 = 1331 combinations on a low cap of 100.
+    book = _book_with_widget_notebook(
+        tmp_path,
+        source="\n    ".join(
+            [
+                "a = mo.ui.slider(0, 10, step=1)",
+                "b = mo.ui.slider(0, 10, step=1)",
+                "c = mo.ui.slider(0, 10, step=1)",
+            ]
+        ),
+    )
+    book = _enable_precompute(book, max_combinations_per_page=100)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 3
+    assert any("max_combinations_per_page" in w for w in report.warnings)
+
+
+def test_preview_excluded_page_is_silent(tmp_path: Path) -> None:
+    book = _book_with_widget_notebook(tmp_path, source="slider = mo.ui.slider(steps=[0, 1, 5, 10])")
+    book = _enable_precompute(book, exclude_pages=["content/demo.py"])
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 0
+    assert not report.warnings


### PR DESCRIPTION
First of two PRs adding precomputed interactivity for marimo's discrete UI widgets. This one ships the foundation; the actual per-value re-export pipeline + client-side JS swap shim ship in PR #7.

**Held off any release until both PRs land.** Plan file: \`/Users/lukechang/.claude/plans/i-wanted-to-check-tingly-tide.md\`.

## Design (Option D — marimo-native)

- **The widget IS the annotation.** Authors write normal marimo code; the choice between discrete and continuous widgets implicitly declares precompute candidacy. Zero imports from marimo-book in the notebook.
- \`mo.ui.slider(steps=[...])\` or \`mo.ui.slider(start, stop, step=N)\` → candidate. Bare \`mo.ui.slider(0, 10)\` → continuous, skipped.
- \`mo.ui.dropdown\` / \`switch\` / \`checkbox\` / \`radio\` → always candidates when enabled.
- Notebooks stay portable in marimo's own runtime.

## Caps (compute + bundle, plus cheap count pre-checks)

| Cap | Default | When checked |
|---|---|---|
| \`max_values_per_widget\` | 50 | Before execution (this PR) |
| \`max_combinations_per_page\` | 200 | Before execution (this PR) |
| \`max_seconds_per_page\` | 60 | After first re-export (PR #7) |
| \`max_bytes_per_page\` | 10 MB | Per combination (PR #7) |
| \`exclude_pages\` | \`[]\` | Per-page opt-out |

**Failure mode:** graceful skip → static render + warning. Build doesn't fail unless \`--strict\`.

## What's in this PR (Phase 1+2)

- \`book.yml\` \`precompute:\` block with the five caps + exclude list.
- \`src/marimo_book/transforms/precompute.py\` — AST scanner that finds candidates without executing.
- \`Preprocessor._preview_precompute\` — runs the scan + count caps when \`enabled: true\`, surfaces over-cap widgets/pages as \`BuildReport.warnings\`.
- \`BuildReport\` gains \`widgets_precomputed\` / \`widgets_skipped\` counters.
- Build cache invalidates when the precompute block changes (in \`_book_signature\`).

## What's NOT in this PR (Phase 3+4+5, queued for PR #7)

- Actual per-value re-export pipeline.
- Client-side JS shim that swaps outputs on widget input.
- Demo chapter in the docs site.
- Building.md "Static reactivity" section.

Until PR #7 lands, \`widgets_precomputed\` is a *would-precompute* count — useful for tuning caps before paying for execution.

## Test plan

- [x] 89/89 tests passing (27 new in \`tests/test_precompute.py\`)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Manually verified: enabling \`precompute.enabled: true\` on a fixture book produces correct \`widgets_precomputed\` count + correct over-cap warnings
- [ ] PR #7 lands the actual interactivity; release \`v0.1.0a5\` only after both merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)