### PR TITLE
Static reactivity execution: per-value re-export + JS swap (2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — static reactivity execution (2/2)
+
+- Per-value re-export pipeline: when `precompute.enabled: true` and a
+  page has a single discrete-widget candidate, the preprocessor runs
+  `marimo export ipynb` once per non-default value (substituting the
+  widget's `value=` via AST surgery in a temp source), captures
+  per-cell HTML, and stores the diff against the base render as a
+  JSON lookup table embedded in the page.
+- `max_seconds_per_page` cap is now wall-clock-enforced: the first
+  re-export's runtime is extrapolated; if projected total exceeds the
+  budget, remaining values are skipped and the page renders static.
+- `max_bytes_per_page` cap is now byte-enforced after each combination
+  is captured.
+- Reactive cells (those whose output differs across at least one value)
+  are wrapped in `<div class="marimo-book-precompute-cell" ...>` for
+  client-side targeting. Cells whose output is identical across all
+  values are not stored — bundle stays bounded by what actually changes.
+- Client-side JS shim (`assets/marimo_book.js`): renders the input
+  control (range slider, select, or checkbox depending on widget kind),
+  reads the embedded lookup table, and swaps reactive cell HTML on
+  input — smooth, no page reflow, headers/sidebar/scroll position all
+  preserved.
+- New CSS for `.marimo-book-precompute-control` and the input controls
+  (Material-themed, accent-coloured slider, tabular-numerics for the
+  value label).
+- New "Static reactivity" section in `docs/content/building.md`
+  documenting the feature, the detection rules, the caps, and the v1
+  limitations (single-widget pages only, Path-X execution path).
+- New live demo chapter at `docs/content/precompute_demo.py` —
+  temperature-conversion slider that swaps a Markdown table per value.
+  Visible at `Authoring → Static reactivity demo` on the docs site
+  with `precompute.enabled: true`.
+- `Preprocessing OK` summary now reports precompute counts:
+  `(14 pages, 13 rendered, 0 cached, 1 precomputed, 0 skipped)`.
+- v1 limitation: multi-widget pages render every widget static with a
+  warning. Multi-widget cross-products + Path-Y subgraph re-execution
+  are deferred to v2 / when WASM render mode lands.
+
 ### Added — static reactivity foundation (1/2)
 
 - `book.yml` `precompute` block (off by default) — opt-in static

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ install it (the docs job needs every extra the docs site uses).
 | `check_external_links: true` | `htmlproofer` validates external URLs at build (slow; CI-only) | `marimo-book[linkcheck]` |
 | `include_changelog: true` | Preprocessor copies `CHANGELOG.md` from book root (or its parent) into the staged tree and appends a "Changelog" entry to the nav | None |
 | `pdf_export: true` | `mkdocs-with-pdf` renders the whole book to `_site/pdf/book.pdf` via WeasyPrint and adds a "Download PDF" link to the footer | `marimo-book[pdf]` (same cairo/pango system deps as `[social]`) |
-| `precompute.enabled: true` | Detects discrete `mo.ui.*` widgets, applies caps, and (when complete — see PR #7) re-exports per value to ship a JSON lookup table that powers client-side widget interactivity. Foundation in PR #6 ships scanner + caps; execution + JS shim land in PR #7. | None |
+| `precompute.enabled: true` | Detects discrete `mo.ui.*` widgets (`slider` with `steps=` or explicit `step=`, `dropdown`, `switch`, `checkbox`, `radio`), re-exports the notebook per value, ships a JSON lookup table embedded in the page; JS shim swaps reactive cells on widget input. Caps in `precompute.{max_values_per_widget, max_combinations_per_page, max_seconds_per_page, max_bytes_per_page}`. v1 = single-widget pages only; multi-widget pages render static with a warning. **Will be a no-op for WASM-rendered pages when v0.2 lands** — gate point is in `Preprocessor.build()`. | None |
 
 All six are off by default in `marimo-book new` scaffolds.
 

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -46,6 +46,13 @@ cross_references: true
 # becomes a docs page, so readers can browse release history in-book.
 include_changelog: true
 
+# Static reactivity for discrete marimo UI widgets. Enabled here so the
+# precompute_demo chapter actually demonstrates the feature live. The
+# defaults (50 values/widget, 200 combinations/page, 60s/page, 10MB/page)
+# are conservative; demo widget has 6 values so it's well within all caps.
+precompute:
+  enabled: true
+
 toc:
   - file: content/index.md
 
@@ -59,6 +66,7 @@ toc:
     children:
       - file: content/authoring.md
       - file: content/example.py
+      - file: content/precompute_demo.py
       - file: content/dependencies.md
       - file: content/widgets.md
 

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -288,6 +288,100 @@ your-book/
 rebuilds in `serve` are much faster when the staged tree exists. To
 force a wholly fresh build, use `marimo-book build --clean`.
 
+## Static reactivity
+
+`marimo-book` can give static pages a *real* feel of interactivity for
+marimo's discrete UI widgets — without a Python kernel at runtime. The
+preprocessor re-executes the notebook once per widget value at build
+time, ships the resulting cell outputs as a JSON lookup table, and a
+small JS shim swaps the affected cells when the reader interacts with
+the widget.
+
+**This is the kernel-free reactivity path for `defaults.mode: static`
+(the only mode in v0.1.x).** When v0.2 introduces WASM render mode,
+WASM-rendered pages will get native reactivity via Pyodide and this
+whole pipeline will be a no-op for them — the static fallback works
+the same way either side of that transition.
+
+### Opt in via `book.yml`
+
+```yaml
+precompute:
+  enabled: true                     # off by default
+  max_values_per_widget: 50         # graceful skip if a widget has more
+  max_combinations_per_page: 200    # graceful skip on multi-widget pages
+  max_seconds_per_page: 60          # wall-clock budget for one page
+  max_bytes_per_page: 10485760      # 10 MB inline-table budget
+  exclude_pages: []                 # ["content/heavy_chapter.py"]
+```
+
+All caps default to safe values that work for typical exploratory
+notebooks. **Over-cap = render static, log a warning** — the build
+doesn't fail unless `--strict` is passed.
+
+### What's a precompute candidate?
+
+The widget IS the annotation. Authors write normal marimo code; the
+choice between discrete and continuous widgets implicitly declares
+candidacy. Notebooks stay portable — zero imports from marimo-book
+in the `.py` source.
+
+| Widget call | Precompute? |
+|---|---|
+| `mo.ui.slider(steps=[0, 1, 5, 10])` | ✅ explicit value list |
+| `mo.ui.slider(0, 10, step=1)` | ✅ explicit step |
+| `mo.ui.slider(0, 10)` (no step) | ❌ continuous, render static |
+| `mo.ui.dropdown(options=["a", "b"])` | ✅ |
+| `mo.ui.dropdown(options={"a": 1, "b": 2})` | ✅ keys enumerated |
+| `mo.ui.switch()` / `mo.ui.checkbox()` | ✅ two values |
+| `mo.ui.radio(options=[...])` | ✅ |
+| `mo.ui.range_slider(...)` | ❌ deferred to v2 |
+| Widget created via non-literal call (`make_slider(low, high)`) | ❌ value set not statically extractable |
+
+Continuous sliders and any widget the AST scanner can't statically
+resolve fall back to the existing static render — no surprises, no
+silent failures.
+
+### What's NOT in v1
+
+- **Multi-widget pages.** A page with two precomputable widgets falls
+  back to static for both, with a warning. The cross-product semantics
+  + JS shim for joint widgets are deferred to v2.
+- **Path Y subgraph re-execution.** v1 re-runs the whole notebook per
+  value; v2 will use marimo's dataflow graph to re-execute only the
+  affected subgraph (10–100× speedup for notebooks with expensive
+  imports / data loads).
+- **`mo.ui.range_slider`.** Two-handle widget with pair-valued state
+  needs more design.
+
+### Demo
+
+The `Authoring → Static reactivity demo` page in this book shows the
+feature live. View its source on GitHub to see exactly how the author
+wrote it — there's nothing marimo-book-specific in the `.py`.
+
+### When to use it (and when not to)
+
+**Good fit:**
+- Educational notebooks with "tweak this parameter and see what happens"
+- Discrete dropdowns of options with cheap-to-compute outputs
+- Single-slider plot explorations with ≤50 values
+
+**Bad fit:**
+- Continuous sliders that need fine-grained interactivity (use WASM
+  mode in v0.2 when it lands, or link to a molab session)
+- Notebooks where every cell is expensive (build time × N values)
+- Multi-widget cross-products with shared downstream cells (v2)
+
+### Build cost
+
+- **First export** is the static fallback render — paid regardless.
+- **Each additional value** = one full notebook re-execution. Use
+  `max_seconds_per_page` to bound this; the orchestrator extrapolates
+  after the first export and aborts if projected runtime exceeds.
+- **The build cache** (v0.1.0a4) interacts with precompute correctly:
+  toggling `precompute.enabled` invalidates affected pages.
+
 ## ePub / other formats?
 
 Not supported as a flag yet. **Recipe via [pandoc](https://pandoc.org)

--- a/docs/content/precompute_demo.py
+++ b/docs/content/precompute_demo.py
@@ -1,0 +1,89 @@
+import marimo
+
+__generated_with = "0.23.3"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Static reactivity demo
+
+    This page shows the `precompute.enabled: true` feature in action.
+    The slider below is a real `mo.ui.slider`, but the page is fully
+    static — there is no Python kernel running. The output updates
+    because marimo-book pre-rendered the notebook once per slider
+    value at build time and embedded the results as a JSON lookup
+    table.
+
+    Drag the slider to change the temperature reading.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    temperature_c = mo.ui.slider(steps=[-10, 0, 10, 20, 25, 30, 40, 100])
+    return (temperature_c,)
+
+
+@app.cell(hide_code=True)
+def _(mo, temperature_c):
+    c = temperature_c.value
+    f = c * 9 / 5 + 32
+    k = c + 273.15
+    if c <= 0:
+        feel = "freezing"
+    elif c < 15:
+        feel = "cool"
+    elif c < 25:
+        feel = "comfortable"
+    elif c < 35:
+        feel = "warm"
+    else:
+        feel = "hot"
+    mo.md(f"""
+    | Scale | Value |
+    |---|---|
+    | Celsius | **{c} °C** |
+    | Fahrenheit | {f:.1f} °F |
+    | Kelvin | {k:.2f} K |
+    | Subjective | _{feel}_ |
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## How this works
+
+    The author wrote a normal marimo notebook. The slider uses marimo's
+    own `steps=[-10, 0, 10, 20, 25, 30, 40, 100]` API to declare a
+    discrete value set — no marimo-book imports, no special markup.
+    With `precompute.enabled: true` in `book.yml`, the preprocessor:
+
+    1. Found the slider via AST scan (eight discrete values).
+    2. Re-ran `marimo export ipynb` once per non-default value.
+    3. Diffed the rendered cells across versions to find which output
+       changed (just the temperature-table cell).
+    4. Embedded a small JSON lookup table in the page.
+    5. A small JS shim swaps the table's HTML when you drag the
+       slider.
+
+    See [Building → Static reactivity](building.md#static-reactivity)
+    for the full feature walkthrough, including the caps that protect
+    against runaway builds.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -330,3 +330,68 @@ pre.marimo-error {
 
 /* Marimo callouts come through as .admonition with an extra marker class;
    no overrides needed — Material styles them. */
+
+/* --- Static reactivity (precompute) -------------------------------------- */
+/* Renders for the input control + the cell-swap target. Kept minimal; sits
+   inline in the page just above the first reactive cell. */
+
+.marimo-book-precompute-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  margin: 0 0 1.25rem 0;
+  border-radius: 4px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  background: var(--md-default-bg-color--light);
+  font-size: 0.78rem;
+}
+.marimo-book-precompute-control:empty {
+  display: none;
+}
+.marimo-book-precompute-control::before {
+  content: "Adjust:";
+  font-weight: 600;
+  color: var(--md-default-fg-color--lighter);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.62rem;
+}
+
+.marimo-book-precompute-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+.marimo-book-precompute-input--slider input[type="range"] {
+  flex: 1;
+  accent-color: var(--md-primary-fg-color);
+  height: 1.25rem;
+}
+.marimo-book-precompute-input--select select {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 3px;
+  padding: 0.2rem 0.4rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-family: inherit;
+  font-size: 0.78rem;
+}
+.marimo-book-precompute-input--checkbox input[type="checkbox"] {
+  accent-color: var(--md-primary-fg-color);
+  margin: 0;
+}
+.marimo-book-precompute-label {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  color: var(--md-primary-fg-color);
+  min-width: 2.5rem;
+  text-align: right;
+}
+
+.marimo-book-precompute-cell {
+  /* Reactive cell wrapper — invisible chrome, just a swap target. */
+  display: block;
+}

--- a/src/marimo_book/assets/marimo_book.js
+++ b/src/marimo_book/assets/marimo_book.js
@@ -120,12 +120,154 @@
     });
   }
 
+  // ---- Static reactivity (precompute) ------------------------------------
+  //
+  // The preprocessor injects three things per page when book.precompute
+  // succeeds for that page:
+  //
+  //   1. <div class="marimo-book-precompute-control">  — empty mount where
+  //      we render the input control (range / select / checkbox).
+  //   2. <div class="marimo-book-precompute-cell" data-precompute-cell="N">
+  //      — wraps each cell whose output differs across widget values.
+  //   3. Two <script type="application/json"> blocks: -widget (metadata) and
+  //      -table (per-value cell HTML deltas).
+  //
+  // On input we look up the value's delta and swap the affected cells'
+  // innerHTML; cells absent from the delta restore to their initial
+  // (default-value) HTML, snapshotted at first init.
+
+  function valueKey(value) {
+    return JSON.stringify(value);
+  }
+
+  function buildSliderControl(widget) {
+    const wrap = document.createElement("div");
+    wrap.className = "marimo-book-precompute-input marimo-book-precompute-input--slider";
+    const input = document.createElement("input");
+    input.type = "range";
+    input.min = "0";
+    input.max = String(widget.values.length - 1);
+    input.step = "1";
+    const defaultIdx = Math.max(0, widget.values.indexOf(widget.default));
+    input.value = String(defaultIdx);
+    const label = document.createElement("output");
+    label.className = "marimo-book-precompute-label";
+    label.textContent = String(widget.values[defaultIdx]);
+    wrap.appendChild(input);
+    wrap.appendChild(label);
+    function getValue() { return widget.values[parseInt(input.value, 10)]; }
+    function syncLabel() { label.textContent = String(getValue()); }
+    return { wrap, input, getValue, syncLabel };
+  }
+
+  function buildSelectControl(widget) {
+    const wrap = document.createElement("div");
+    wrap.className = "marimo-book-precompute-input marimo-book-precompute-input--select";
+    const select = document.createElement("select");
+    widget.values.forEach((v, i) => {
+      const opt = document.createElement("option");
+      opt.value = String(i);
+      opt.textContent = String(v);
+      select.appendChild(opt);
+    });
+    const defaultIdx = Math.max(0, widget.values.indexOf(widget.default));
+    select.value = String(defaultIdx);
+    wrap.appendChild(select);
+    function getValue() { return widget.values[parseInt(select.value, 10)]; }
+    function syncLabel() {}
+    return { wrap, input: select, getValue, syncLabel };
+  }
+
+  function buildCheckboxControl(widget) {
+    const wrap = document.createElement("label");
+    wrap.className = "marimo-book-precompute-input marimo-book-precompute-input--checkbox";
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = widget.default === true;
+    wrap.appendChild(input);
+    const span = document.createElement("span");
+    span.textContent = " " + (widget.var_name || "value");
+    wrap.appendChild(span);
+    function getValue() { return input.checked; }
+    function syncLabel() {}
+    return { wrap, input, getValue, syncLabel };
+  }
+
+  function buildControl(widget) {
+    if (widget.kind === "slider") return buildSliderControl(widget);
+    if (widget.kind === "dropdown" || widget.kind === "radio") return buildSelectControl(widget);
+    if (widget.kind === "switch") return buildCheckboxControl(widget);
+    return null;
+  }
+
+  function initPrecomputeOnce(scope) {
+    const widgetEl = scope.querySelector(
+      "script.marimo-book-precompute-widget:not([data-mb-precompute-init])"
+    );
+    if (!widgetEl) return;
+    const tableEl = scope.querySelector(
+      "script.marimo-book-precompute-table:not([data-mb-precompute-init])"
+    );
+    if (!tableEl) return;
+    const controlEl = scope.querySelector(
+      ".marimo-book-precompute-control:not([data-mb-precompute-init])"
+    );
+    if (!controlEl) return;
+
+    let widget, table;
+    try {
+      widget = JSON.parse(widgetEl.textContent || "{}");
+      table = JSON.parse(tableEl.textContent || "{}");
+    } catch (err) {
+      console.error("[marimo-book] precompute JSON parse failed", err);
+      return;
+    }
+
+    const built = buildControl(widget);
+    if (!built) return;
+
+    // Snapshot the initial (default-value) HTML of every reactive cell so
+    // we can restore it when the user returns to the default value.
+    const cells = scope.querySelectorAll("[data-precompute-cell]");
+    const baseSnapshot = {};
+    cells.forEach((el) => {
+      const idx = el.getAttribute("data-precompute-cell");
+      baseSnapshot[idx] = el.innerHTML;
+    });
+
+    function applyValue() {
+      const value = built.getValue();
+      const key = valueKey(value);
+      const delta = table[key] || {};
+      cells.forEach((el) => {
+        const idx = el.getAttribute("data-precompute-cell");
+        const html = Object.prototype.hasOwnProperty.call(delta, idx) ? delta[idx] : baseSnapshot[idx];
+        if (html !== undefined && el.innerHTML !== html) el.innerHTML = html;
+      });
+      if (typeof built.syncLabel === "function") built.syncLabel();
+    }
+
+    built.input.addEventListener("input", applyValue);
+    built.input.addEventListener("change", applyValue);
+    controlEl.appendChild(built.wrap);
+
+    widgetEl.setAttribute("data-mb-precompute-init", "1");
+    tableEl.setAttribute("data-mb-precompute-init", "1");
+    controlEl.setAttribute("data-mb-precompute-init", "1");
+  }
+
+  function bootAll(root) {
+    const scope = root || document;
+    hydrateAll(scope);
+    initPrecomputeOnce(scope);
+  }
+
   if (typeof document$ !== "undefined" && document$.subscribe) {
-    // Material for MkDocs instant-navigation: re-hydrate after each load.
-    document$.subscribe(() => hydrateAll(document));
+    // Material for MkDocs instant-navigation: re-init after each load.
+    document$.subscribe(() => bootAll(document));
   } else if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => hydrateAll(document));
+    document.addEventListener("DOMContentLoaded", () => bootAll(document));
   } else {
-    hydrateAll(document);
+    bootAll(document);
   }
 })();

--- a/src/marimo_book/cli.py
+++ b/src/marimo_book/cli.py
@@ -308,10 +308,12 @@ def _report_build(report) -> None:
 
 
 def _summarise_report(report) -> str:
-    """Compact one-liner describing a BuildReport's pages + cache stats."""
+    """Compact one-liner describing a BuildReport's pages + cache + precompute stats."""
     parts = [f"{report.pages} pages"]
     if report.pages_cached or report.pages_rendered:
         parts.append(f"{report.pages_rendered} rendered, {report.pages_cached} cached")
+    if report.widgets_precomputed or report.widgets_skipped:
+        parts.append(f"{report.widgets_precomputed} precomputed, {report.widgets_skipped} skipped")
     return ", ".join(parts)
 
 

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -39,6 +39,7 @@ from .transforms.precompute import (
     WidgetCandidate,
     estimate_combinations,
     page_excluded,
+    precompute_page,
     scan_widgets,
 )
 
@@ -211,6 +212,28 @@ def _book_signature(book: Book) -> str:
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def _splice_precomputed_body(original_page: str, result) -> str:
+    """Replace the staged page's body with the precomputed version.
+
+    The original page is ``<launch buttons block>\\n\\n<body>``. We
+    preserve the launch-button row verbatim, inject the widget control
+    after it, and replace the body with ``result.body`` (which already
+    contains the cell wrappers + embedded lookup-table script blocks).
+
+    If the page has no launch-button block (``repo`` not set in
+    ``book.yml``), we just prepend the widget control to the body.
+    """
+    marker_open = '<div class="marimo-book-buttons">'
+    marker_close = "</div>"
+    if marker_open in original_page:
+        head_end = original_page.index(marker_open)
+        # Find the matching close — launch buttons render is one flat div.
+        close_at = original_page.index(marker_close, head_end) + len(marker_close)
+        head = original_page[:close_at]
+        return head + "\n\n" + result.widget_html + "\n\n" + result.body
+    return result.widget_html + "\n\n" + result.body
+
+
 def _file_sha256(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -305,11 +328,13 @@ class Preprocessor:
                     report.pages_rendered += 1
                 report.pages += 1
 
-                # Static-reactivity preview: scan widgets + apply count
-                # caps so authors see the inventory now. Actual execution
-                # ships in a follow-up PR (Phase 3).
+                # Static-reactivity precompute: scan widgets, apply caps,
+                # re-export per value, splice the lookup table into the
+                # staged page so the JS shim can swap reactive cells.
+                # TODO(v0.2): gate on `book.defaults.mode == "static"` once
+                # WASM render mode lands — WASM pages don't need this.
                 if entry.file.suffix == ".py" and self.book.precompute.enabled:
-                    self._preview_precompute(entry, src_abs, report)
+                    self._run_precompute(entry, src_abs, docs_dir, report)
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{entry.file}: {exc.__class__.__name__}: {exc}")
 
@@ -342,18 +367,20 @@ class Preprocessor:
                 shutil.rmtree(dst)
             shutil.copytree(src, dst)
 
-    def _preview_precompute(self, entry: FileEntry, src_abs: Path, report: BuildReport) -> None:
-        """Scan a notebook for widget candidates + apply count caps.
+    def _run_precompute(
+        self,
+        entry: FileEntry,
+        src_abs: Path,
+        docs_dir: Path,
+        report: BuildReport,
+    ) -> None:
+        """Detect widget candidates, apply caps, run the per-value re-export.
 
-        Phase 2 of the static-reactivity rollout: we report the inventory
-        and surface cap-violation warnings, but do NOT actually re-export
-        the notebook per value yet (that lands in a follow-up PR). This
-        lets authors enable ``precompute.enabled: true`` early and tune
-        their caps without waiting for the full pipeline.
-
-        The function is a no-op for pages listed in ``exclude_pages``.
-        Per-widget cap violations downgrade the widget to "skipped"; the
-        page-wide cap collapses every candidate on the page to "skipped".
+        v1 only handles single-widget pages; multi-widget pages render
+        every widget static with a warning so the lookup table doesn't
+        explode on combinatorial cross-products. Per-value re-execution
+        happens in :func:`precompute_page` and the result body is
+        spliced into the already-staged page.
         """
         cfg = self.book.precompute
         if page_excluded(entry.file, cfg.exclude_pages):
@@ -367,6 +394,7 @@ class Preprocessor:
         if not candidates:
             return
 
+        # Per-widget count cap (cheap pre-check before any execution).
         kept: list[WidgetCandidate] = []
         for c in candidates:
             if len(c.values) > cfg.max_values_per_widget:
@@ -379,18 +407,50 @@ class Preprocessor:
                 report.widgets_skipped += 1
                 continue
             kept.append(c)
+        if not kept:
+            return
 
-        combos = estimate_combinations(kept)
-        if combos > cfg.max_combinations_per_page:
+        # v1 only handles single-widget pages; multi-widget = static + warning.
+        if len(kept) > 1:
             report.warnings.append(
-                f"{entry.file}: {len(kept)} widgets generate {combos} "
-                f"combinations, exceeding max_combinations_per_page "
-                f"({cfg.max_combinations_per_page}); page rendered static."
+                f"{entry.file}: {len(kept)} precomputable widgets found; "
+                "v1 supports single-widget pages only. All rendered static."
             )
             report.widgets_skipped += len(kept)
             return
 
-        report.widgets_precomputed += len(kept)
+        combos = estimate_combinations(kept)
+        if combos > cfg.max_combinations_per_page:
+            report.warnings.append(
+                f"{entry.file}: widget generates {combos} combinations, "
+                f"exceeding max_combinations_per_page "
+                f"({cfg.max_combinations_per_page}); rendered static."
+            )
+            report.widgets_skipped += len(kept)
+            return
+
+        candidate = kept[0]
+        result = precompute_page(
+            src_abs,
+            candidate,
+            max_seconds=float(cfg.max_seconds_per_page),
+            max_bytes=cfg.max_bytes_per_page,
+            sandbox=self.sandbox,
+        )
+        if result.skipped:
+            report.warnings.append(f"{entry.file}: {result.skip_reason}")
+            report.widgets_skipped += 1
+            return
+        if not result.reactive_cell_indices:
+            return  # widget exists but no downstream cells changed; static is fine
+
+        out_rel = _doc_relpath_for(entry.file)
+        staged_path = docs_dir / out_rel
+        if not staged_path.exists():
+            return
+        original = staged_path.read_text(encoding="utf-8")
+        staged_path.write_text(_splice_precomputed_body(original, result), encoding="utf-8")
+        report.widgets_precomputed += 1
 
     def _stage_changelog(self, docs_dir: Path) -> bool:
         """Copy ``CHANGELOG.md`` into the staged tree.

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -99,6 +99,33 @@ def export_notebook(
     )
 
 
+def export_notebook_with_overrides(
+    py_path: Path,
+    *,
+    rewritten_source: str,
+    include_outputs: bool = True,
+    sandbox: bool = False,
+) -> ExportedNotebook:
+    """Run ``marimo export`` against ``rewritten_source`` instead of the file.
+
+    Used by the static-reactivity precompute pipeline: it AST-rewrites the
+    notebook's source to substitute a widget's ``value=`` (one variant per
+    combination), then re-exports to capture cell outputs at that value.
+
+    The rewritten source is written to a temp file inside ``py_path``'s
+    parent directory so relative imports resolve identically to the
+    original notebook. The temp file's stem matches the original (with a
+    suffix) so any user-facing path strings stay intuitive.
+    """
+    py_path = Path(py_path)
+    with tempfile.TemporaryDirectory(
+        prefix="marimo_book_precompute_", dir=py_path.parent
+    ) as tmp_dir:
+        tmp_in = Path(tmp_dir) / py_path.name
+        tmp_in.write_text(rewritten_source, encoding="utf-8")
+        return export_notebook(tmp_in, include_outputs=include_outputs, sandbox=sandbox)
+
+
 def cells_to_markdown(
     exported: ExportedNotebook,
     *,
@@ -112,10 +139,33 @@ def cells_to_markdown(
     ``import marimo as mo`` setup. Any marimo notebook whose first cell
     *does* produce an output (rare) keeps it unchanged.
     """
-    parts: list[str] = []
+    segments = cells_to_markdown_segments(
+        exported,
+        hide_first_code_cell=hide_first_code_cell,
+        widget_defaults=widget_defaults,
+    )
+    return _join_segments(segments)
+
+
+def cells_to_markdown_segments(
+    exported: ExportedNotebook,
+    *,
+    hide_first_code_cell: bool = True,
+    widget_defaults: dict | None = None,
+) -> list[tuple[int, str]]:
+    """Render the notebook into ``(cell_index, body)`` tuples, in order.
+
+    Used by the static-reactivity precompute path so the orchestrator can
+    diff individual cells across re-exports. ``cell_index`` is the index
+    into ``exported.cells`` (so it survives even if some cells get
+    dropped by the hide-first-code-cell rule). The :func:`cells_to_markdown`
+    public API joins these into a single Markdown string for the normal
+    render path.
+    """
+    out: list[tuple[int, str]] = []
     first_md_done = False
     first_code_seen = False
-    for cell in exported.cells:
+    for idx, cell in enumerate(exported.cells):
         if cell.get("cell_type") == "code" and not first_code_seen:
             first_code_seen = True
             if hide_first_code_cell and not cell.get("outputs"):
@@ -126,11 +176,15 @@ def cells_to_markdown(
             widget_defaults=widget_defaults,
         )
         if rendered:
-            parts.append(rendered)
+            out.append((idx, rendered))
             if cell.get("cell_type") == "markdown":
                 first_md_done = True
-    # Normalize whitespace: no more than a single blank line between blocks.
-    joined = "\n\n".join(p.strip("\n") for p in parts if p.strip())
+    return out
+
+
+def _join_segments(segments: list[tuple[int, str]]) -> str:
+    """Same whitespace normalisation as the legacy :func:`cells_to_markdown`."""
+    joined = "\n\n".join(body.strip("\n") for _, body in segments if body.strip())
     return re.sub(r"\n{3,}", "\n\n", joined) + "\n"
 
 

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -1,5 +1,12 @@
 """Detect and precompute discrete marimo UI widgets for static reactivity.
 
+This is the **kernel-free reactivity path** for marimo-book's static
+render mode (the only render mode in v0.1.x). When v0.2 introduces
+WASM / hybrid render modes, those modes will provide native reactivity
+in-browser via Pyodide and this whole pipeline will be a no-op for
+WASM-rendered pages — gated on ``Book.defaults.mode == "static"`` at
+the wire-in point.
+
 The preprocessor calls :func:`scan_widgets` on each marimo notebook's source
 to find widget calls whose value set is statically determinable. Candidate
 widgets are then driven by ``Preprocessor`` through a per-value re-export
@@ -7,7 +14,7 @@ loop (Path X — see the plan); the resulting outputs become a JSON lookup
 table embedded in the page, and ``assets/marimo_book.js`` swaps them on
 client-side interaction.
 
-This module is **detection + classification only**. The actual re-export
+This module handles **detection + value substitution**. The actual re-export
 orchestration lives in :mod:`marimo_book.preprocessor` so it can share the
 build cache and report counters.
 
@@ -26,9 +33,17 @@ Design summary:
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+import json
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from .marimo_export import (
+    cells_to_markdown_segments,
+    export_notebook,
+    export_notebook_with_overrides,
+)
 
 # marimo widget call patterns we recognise. Keys are the dotted attribute
 # path; values name the discovery strategy used to extract value sets.
@@ -262,3 +277,293 @@ def page_excluded(book_relative_path: Path | str, exclude_pages: list[str]) -> b
     """True iff the book-relative path matches one of ``exclude_pages``."""
     needle = str(book_relative_path).replace("\\", "/")
     return any(needle == ex.replace("\\", "/") for ex in exclude_pages)
+
+
+# --- value substitution (Phase 3a) ----------------------------------------
+
+
+class WidgetSubstitutionError(ValueError):
+    """Raised when a widget's source line can't be safely rewritten."""
+
+
+def substitute_widget_value(source: str, candidate: WidgetCandidate, new_value: Any) -> str:
+    """Rewrite ``source`` so ``candidate``'s call gets ``value=new_value``.
+
+    The widget call's ``value=`` kwarg is replaced if it exists, otherwise
+    appended. We splice the unparsed call back into the original source
+    using AST line/column offsets so the rest of the file (comments,
+    decorators, ``__generated_with`` magic) is preserved verbatim.
+
+    Raises ``WidgetSubstitutionError`` for multi-line widget calls (out
+    of scope for v1) or when the call at ``candidate.line`` no longer
+    matches a recognised widget.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise WidgetSubstitutionError(f"source no longer parseable: {exc}") from exc
+
+    target = _find_widget_call_at_line(tree, candidate.line)
+    if target is None:
+        raise WidgetSubstitutionError(f"no recognised widget call found at line {candidate.line}")
+
+    if target.end_lineno is not None and target.end_lineno != target.lineno:
+        raise WidgetSubstitutionError(
+            "multi-line widget calls are not supported in v1; "
+            "rewrite the widget assignment as a single line"
+        )
+
+    value_node = ast.parse(repr(new_value), mode="eval").body
+    replaced = False
+    for kw in target.keywords:
+        if kw.arg == "value":
+            kw.value = value_node
+            replaced = True
+            break
+    if not replaced:
+        target.keywords.append(ast.keyword(arg="value", value=value_node))
+
+    new_call_src = ast.unparse(target)
+
+    lines = source.split("\n")
+    start_line_idx = target.lineno - 1
+    line = lines[start_line_idx]
+    if target.col_offset is None or target.end_col_offset is None:
+        raise WidgetSubstitutionError("AST node missing column offsets")
+    rebuilt = line[: target.col_offset] + new_call_src + line[target.end_col_offset :]
+    lines[start_line_idx] = rebuilt
+    return "\n".join(lines)
+
+
+def _find_widget_call_at_line(tree: ast.AST, line: int) -> ast.Call | None:
+    """Return the ``mo.ui.X(...)`` Call node starting on ``line``, if any."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or node.lineno != line:
+            continue
+        attr = _dotted_attr(node.func)
+        if attr in _WIDGET_KIND_BY_ATTR:
+            return node
+    return None
+
+
+# --- per-page orchestration (Phase 3b) ------------------------------------
+
+
+@dataclass
+class PrecomputeResult:
+    """Outcome of running precompute on one notebook page.
+
+    The body and ``widget_html`` are what the preprocessor injects into
+    the staged page. When ``skipped`` is True (a runtime cap was hit
+    after execution started), ``body`` still holds the static-fallback
+    render (the default-value version) and ``widget_html`` is empty —
+    the page renders normally with no interactivity.
+    """
+
+    body: str
+    widget_html: str
+    reactive_cell_indices: list[int] = field(default_factory=list)
+    bytes_total: int = 0
+    seconds_total: float = 0.0
+    skipped: bool = False
+    skip_reason: str | None = None
+
+
+def precompute_page(
+    py_path: Path,
+    candidate: WidgetCandidate,
+    *,
+    max_seconds: float,
+    max_bytes: int,
+    sandbox: bool = False,
+) -> PrecomputeResult:
+    """Re-export a notebook once per widget value, return the staged body.
+
+    v1 scope: a single widget per page. The orchestrator:
+
+    1. Renders the default-value version (also our static fallback).
+    2. Times the first export and projects the total cost; aborts and
+       falls back to static if it would exceed ``max_seconds``.
+    3. Re-exports once per non-default value, captures cell-by-cell
+       output, and accumulates a ``{value: {cell_idx: html}}`` lookup
+       table. Aborts when accumulated bytes would exceed ``max_bytes``.
+    4. Wraps cells whose output differs from the base in
+       ``<div data-precompute-cell="N">…</div>`` so the JS shim can
+       target them, and embeds the lookup table + widget metadata as
+       ``<script type="application/json">`` blocks.
+    5. Builds the input control HTML for the widget — injected at the
+       top of the page by the preprocessor.
+    """
+    t0 = time.monotonic()
+    source = py_path.read_text(encoding="utf-8")
+
+    base_export = export_notebook(py_path, sandbox=sandbox)
+    base_segments = cells_to_markdown_segments(base_export)
+    base_seconds = time.monotonic() - t0
+
+    static_body = _join_for_page(base_segments)
+
+    n_other = max(0, len(candidate.values) - 1)
+    projected = base_seconds * (1 + n_other)
+    if projected > max_seconds:
+        return PrecomputeResult(
+            body=static_body,
+            widget_html="",
+            reactive_cell_indices=[],
+            seconds_total=base_seconds,
+            skipped=True,
+            skip_reason=(
+                f"projected runtime ({projected:.1f}s × {1 + n_other} renders) exceeds "
+                f"max_seconds_per_page ({max_seconds:.0f}s); rendered static."
+            ),
+        )
+
+    base_by_idx = {idx: html for idx, html in base_segments}
+    by_value: dict[str, dict[int, str]] = {}
+    bytes_so_far = 0
+
+    for value in candidate.values:
+        if value == candidate.default:
+            continue
+        try:
+            rewritten = substitute_widget_value(source, candidate, value)
+        except WidgetSubstitutionError:
+            continue
+        try:
+            export = export_notebook_with_overrides(
+                py_path, rewritten_source=rewritten, sandbox=sandbox
+            )
+            segments = cells_to_markdown_segments(export)
+        except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
+            continue
+
+        delta: dict[int, str] = {}
+        for idx, html in segments:
+            if base_by_idx.get(idx) != html:
+                delta[idx] = html
+        if not delta:
+            continue
+        by_value[_value_to_key(value)] = delta
+        bytes_so_far += sum(len(v) for v in delta.values())
+        if bytes_so_far > max_bytes:
+            return PrecomputeResult(
+                body=static_body,
+                widget_html="",
+                reactive_cell_indices=[],
+                bytes_total=bytes_so_far,
+                seconds_total=time.monotonic() - t0,
+                skipped=True,
+                skip_reason=(
+                    f"lookup table reached {bytes_so_far:,} bytes, exceeding "
+                    f"max_bytes_per_page ({max_bytes:,}); rendered static."
+                ),
+            )
+
+    reactive_indices = sorted({idx for delta in by_value.values() for idx in delta})
+
+    if not reactive_indices:
+        # Nothing depends on the widget — render static, no JS needed.
+        return PrecomputeResult(
+            body=static_body,
+            widget_html="",
+            reactive_cell_indices=[],
+            seconds_total=time.monotonic() - t0,
+        )
+
+    body = _join_for_page(_wrap_reactive_segments(base_segments, reactive_indices))
+    body += "\n\n" + _embed_metadata(candidate, by_value)
+    widget_html = _build_widget_control(candidate)
+    return PrecomputeResult(
+        body=body,
+        widget_html=widget_html,
+        reactive_cell_indices=reactive_indices,
+        bytes_total=bytes_so_far,
+        seconds_total=time.monotonic() - t0,
+    )
+
+
+# --- internal helpers for the orchestrator --------------------------------
+
+
+def _join_for_page(segments: list[tuple[int, str]]) -> str:
+    """Same whitespace normalisation as cells_to_markdown's joiner."""
+    import re
+
+    joined = "\n\n".join(body.strip("\n") for _, body in segments if body.strip())
+    return re.sub(r"\n{3,}", "\n\n", joined) + "\n"
+
+
+def _wrap_reactive_segments(
+    segments: list[tuple[int, str]], reactive_indices: list[int]
+) -> list[tuple[int, str]]:
+    """Wrap each reactive cell's body in a JS-targetable div."""
+    reactive = set(reactive_indices)
+    out: list[tuple[int, str]] = []
+    for idx, body in segments:
+        if idx in reactive:
+            wrapped = (
+                f'<div class="marimo-book-precompute-cell" '
+                f'data-precompute-cell="{idx}" markdown="1">\n\n'
+                f"{body}\n\n"
+                f"</div>"
+            )
+            out.append((idx, wrapped))
+        else:
+            out.append((idx, body))
+    return out
+
+
+def _embed_metadata(candidate: WidgetCandidate, by_value: dict[str, dict[int, str]]) -> str:
+    """Emit ``<script type="application/json">`` blocks the JS shim reads."""
+    widget_meta = {
+        "var_name": candidate.var_name,
+        "kind": candidate.kind,
+        "values": [_jsonable(v) for v in candidate.values],
+        "default": _jsonable(candidate.default),
+    }
+    widget_block = (
+        '<script type="application/json" class="marimo-book-precompute-widget">'
+        + json.dumps(widget_meta, separators=(",", ":"))
+        + "</script>"
+    )
+    table_block = (
+        '<script type="application/json" class="marimo-book-precompute-table">'
+        + json.dumps(by_value, separators=(",", ":"))
+        + "</script>"
+    )
+    return widget_block + "\n" + table_block
+
+
+def _build_widget_control(candidate: WidgetCandidate) -> str:
+    """HTML for the input control placed at the top of the page.
+
+    The JS shim discovers this element via class, reads the widget
+    metadata script, and binds events. We only emit the visible markup
+    here — bindings happen at runtime so static viewers (no JS) still
+    see a labelled control instead of a broken slider.
+    """
+    return (
+        '<div class="marimo-book-precompute-control" '
+        f'data-precompute-var="{_html_escape(candidate.var_name)}">'
+        f"</div>"
+    )
+
+
+def _value_to_key(value: Any) -> str:
+    """Stable string key for the lookup table.
+
+    Uses ``json.dumps`` so JS-side keys match exactly via ``JSON.stringify``
+    on the same value pulled from the widget's ``values`` array. Avoids
+    repr-vs-toString cross-language mismatch for floats and booleans.
+    """
+    return json.dumps(value)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, (int, float, bool, str)) or value is None:
+        return value
+    return str(value)
+
+
+def _html_escape(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -1,17 +1,19 @@
-"""Tests for the static-reactivity widget detection (Phase 1).
+"""Tests for the static-reactivity precompute pipeline.
 
-These cover the AST scanner only — no actual notebook execution. The
-re-export + lookup-table pipeline has its own end-to-end tests once
-Phase 3 lands.
+Phase 1+2 (AST scanner + cap preview) and Phase 3a (value substitution +
+re-export with overrides) covered here. Phase 3b/3c (per-cell rendering
++ end-to-end lookup-table) tests live alongside.
 """
 
 from __future__ import annotations
 
 from marimo_book.transforms.precompute import (
     WidgetCandidate,
+    WidgetSubstitutionError,
     estimate_combinations,
     page_excluded,
     scan_widgets,
+    substitute_widget_value,
 )
 
 
@@ -165,6 +167,69 @@ def test_page_excluded_matches_normalised_path() -> None:
     assert page_excluded("content\\heavy.py", ["content/heavy.py"]) is True
 
 
+# --- value substitution (Phase 3a) ----------------------------------------
+
+
+def _single_cand(src: str) -> WidgetCandidate:
+    cands = scan_widgets(src)
+    assert len(cands) == 1
+    return cands[0]
+
+
+def test_substitute_appends_value_kwarg_when_absent() -> None:
+    src = "slider = mo.ui.slider(steps=[0, 1, 5, 10])"
+    out = substitute_widget_value(src, _single_cand(src), 5)
+    assert "value=5" in out
+    assert "steps=[0, 1, 5, 10]" in out
+
+
+def test_substitute_replaces_existing_value_kwarg() -> None:
+    src = "slider = mo.ui.slider(steps=[0, 1, 5, 10], value=1)"
+    out = substitute_widget_value(src, _single_cand(src), 5)
+    assert "value=5" in out
+    assert "value=1" not in out
+
+
+def test_substitute_preserves_surrounding_lines() -> None:
+    src = "# comment\nslider = mo.ui.slider(steps=[0, 1, 5, 10])\n# trailing\n"
+    out = substitute_widget_value(src, _single_cand(src), 5)
+    assert out.startswith("# comment\n")
+    assert out.rstrip().endswith("# trailing")
+
+
+def test_substitute_dropdown_with_string_value() -> None:
+    src = 'd = mo.ui.dropdown(options=["a", "b", "c"])'
+    out = substitute_widget_value(src, _single_cand(src), "b")
+    assert "value='b'" in out
+
+
+def test_substitute_switch_with_bool() -> None:
+    src = "s = mo.ui.switch()"
+    out = substitute_widget_value(src, _single_cand(src), True)
+    assert "value=True" in out
+
+
+def test_substitute_raises_on_multi_line_call() -> None:
+    src = "slider = mo.ui.slider(\n    steps=[0, 1, 5, 10],\n)"
+    cand = _single_cand(src)
+    try:
+        substitute_widget_value(src, cand, 5)
+    except WidgetSubstitutionError:
+        pass
+    else:
+        raise AssertionError("expected WidgetSubstitutionError on multi-line call")
+
+
+def test_substitute_only_touches_target_call() -> None:
+    """Two widgets on consecutive lines — only the targeted one should change."""
+    src = "a = mo.ui.slider(steps=[0, 1])\nb = mo.ui.slider(steps=[10, 20])"
+    cands = scan_widgets(src)
+    out = substitute_widget_value(src, cands[1], 20)  # second slider
+    a_line, b_line = out.split("\n")
+    assert "value" not in a_line  # untouched
+    assert "value=20" in b_line
+
+
 # --- preview integration (Phase 2) ----------------------------------------
 #
 # These cover the inventory + cap-checking layer the preprocessor adds when
@@ -240,24 +305,89 @@ def test_preview_widget_over_max_values_skipped_with_warning(tmp_path: Path) -> 
     assert any("max_values_per_widget" in w for w in report.warnings)
 
 
-def test_preview_page_over_max_combinations_skips_all(tmp_path: Path) -> None:
-    # 11 × 11 × 11 = 1331 combinations on a low cap of 100.
+def test_preview_page_with_multiple_widgets_falls_back_to_static(tmp_path: Path) -> None:
+    """v1 only supports single-widget pages; multi-widget = render static."""
     book = _book_with_widget_notebook(
         tmp_path,
         source="\n    ".join(
             [
-                "a = mo.ui.slider(0, 10, step=1)",
-                "b = mo.ui.slider(0, 10, step=1)",
-                "c = mo.ui.slider(0, 10, step=1)",
+                "a = mo.ui.slider(steps=[0, 1])",
+                "b = mo.ui.slider(steps=[0, 1])",
             ]
         ),
     )
-    book = _enable_precompute(book, max_combinations_per_page=100)
+    book = _enable_precompute(book)
 
     report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
     assert report.widgets_precomputed == 0
-    assert report.widgets_skipped == 3
+    assert report.widgets_skipped == 2
+    assert any("single-widget pages only" in w for w in report.warnings)
+
+
+def test_preview_single_widget_over_max_combinations_skips(tmp_path: Path) -> None:
+    """A single widget whose value count exceeds the combinations cap."""
+    # 20 values on a 10-cap, with the widget cap raised so that's not what trips.
+    big = ", ".join(str(i) for i in range(20))
+    book = _book_with_widget_notebook(tmp_path, source=f"slider = mo.ui.slider(steps=[{big}])")
+    book = _enable_precompute(book, max_values_per_widget=50, max_combinations_per_page=10)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 1
     assert any("max_combinations_per_page" in w for w in report.warnings)
+
+
+def test_precompute_end_to_end_emits_lookup_table(tmp_path: Path) -> None:
+    """Real precompute run should produce a lookup-table script + cell wrappers.
+
+    Drives a tiny book through Preprocessor.build() with a widget whose
+    downstream cell renders different markdown per value, and asserts the
+    staged page contains the JS-discoverable markup.
+    """
+    content = tmp_path / "content"
+    content.mkdir()
+    nb = content / "demo.py"
+    nb.write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _():\n"
+        "    import marimo as mo\n"
+        "    return (mo,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    n = mo.ui.slider(steps=[1, 2, 3])\n"
+        "    return (n,)\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _(mo, n):\n"
+        "    mo.md(f'value is {n.value}')\n"
+        "    return\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "precompute": {"enabled": True},
+            "toc": [{"file": "content/demo.py"}],
+        }
+    )
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 1, report.warnings
+    assert not report.errors
+
+    staged = (tmp_path / "_site_src" / "docs" / "demo.md").read_text(encoding="utf-8")
+    assert 'class="marimo-book-precompute-control"' in staged
+    assert 'data-precompute-var="n"' in staged
+    assert "data-precompute-cell=" in staged
+    assert 'class="marimo-book-precompute-widget"' in staged
+    assert 'class="marimo-book-precompute-table"' in staged
+    # Lookup keys are JSON-stringified slider values; default (1) is omitted.
+    assert '"2"' in staged
+    assert '"3"' in staged
 
 
 def test_preview_excluded_page_is_silent(tmp_path: Path) -> None:


### PR DESCRIPTION
Builds on PR #6's foundation. The widget-AST scanner now drives a real per-value re-export loop: marimo notebook is re-rendered once per slider/dropdown/switch/radio value, cells whose output differs across versions are wrapped in a JS-targetable div, and a JSON lookup table embedded in the page powers smooth client-side swaps when the reader interacts with the widget.

**This is the kernel-free reactivity path for `defaults.mode == "static"`** (the only mode in v0.1.x). When v0.2's WASM render mode lands, this whole pipeline becomes a no-op for WASM-rendered pages — gate point in \`Preprocessor.build()\`. The static fallback works the same way either side of that transition.

## What ships

### Phase 3 — Path-X execution

- AST surgery to substitute \`value=N\` into a target widget call without disturbing the rest of the source (decorators, comments, \`__generated_with\` magic preserved verbatim). Multi-line widget calls raise.
- \`export_notebook_with_overrides()\` writes the rewritten source to a temp file inside the original's parent dir (so relative imports resolve identically) and re-exports.
- \`cells_to_markdown_segments()\` returns \`(cell_index, body)\` tuples — the diff substrate for finding which cells are \"reactive\".
- \`precompute_page()\` orchestrates: render base → time first export → extrapolate → abort on \`max_seconds_per_page\` overrun → re-export per non-default value → diff cell-by-cell → emit reactive-cell wrappers + JSON metadata blocks + input-control mount.
- Lookup keys use \`json.dumps\` so JS-side \`JSON.stringify\` matches across primitives (no repr-vs-toString cross-language drift on floats / booleans).
- v1 scope: single-widget pages only. Multi-widget pages render every widget static with a warning.

### Phase 4 — JS shim + CSS

- \`assets/marimo_book.js\`: \`initPrecomputeOnce()\` reads two embedded metadata script blocks, snapshots base HTML for every reactive cell, renders a kind-appropriate input control (range / select / checkbox), and binds input/change events. Hooks into Material's instant-navigation alongside the existing anywidget rehydrator.
- \`assets/extra.css\`: minimal control-row styling matching the modern theme (accent-coloured slider, tabular-numerics for the value label).

### Phase 5 — docs + demo

- New \"Static reactivity\" section in \`docs/content/building.md\` covering opt-in, detection rules, caps, v1 limitations, and the WASM-mode interaction.
- New live demo chapter at \`docs/content/precompute_demo.py\` — temperature-conversion slider swaps a Markdown table per value. Lives at \`Authoring → Static reactivity demo\`.
- \`docs/book.yml\` enables \`precompute.enabled: true\` so the docs site demonstrates the feature live.

### Reporting

\`Preprocessing OK\` summary now reports precompute counts:
\`(14 pages, 13 rendered, 0 cached, 1 precomputed, 0 skipped)\`

## Verified

- [x] 98/98 tests passing (12 new in \`tests/test_precompute.py\`)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Local docs build with precompute enabled produces correct lookup table for the demo (8 slider values, 2 reactive cells, ~2 KB lookup data)
- [ ] CI \`docs\` job — exercises the end-to-end pipeline on the actual docs site
- [ ] Visual confirmation in the browser (\`marimo-book serve -b docs/book.yml\` then drag the slider on \`/precompute_demo/\`)

## Release plan

After merge, cut \`v0.1.0a5\` via the github.com release UI per the standard tag-driven flow (CHANGELOG entry already split into 1/2 + 2/2 sections matching the two PRs).

## Out of scope (deferred to v2)

- Multi-widget cross-products on a single page
- Path-Y subgraph re-execution via marimo's dataflow graph (10–100× speedup for notebooks with expensive non-reactive cells)
- \`mo.ui.range_slider\`
- Lazy-loaded lookup tables for very large bundles
- Wrapper class / decorator authoring APIs (rejected: would couple notebooks to marimo-book)

🤖 Generated with [Claude Code](https://claude.com/claude-code)