### PR TITLE
Date CHANGELOG for v0.1.0a5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0a5] — 2026-04-25
+
+Static reactivity for marimo's discrete UI widgets ships in two
+PRs (#6 + #7). Authors enable `precompute.enabled: true` in `book.yml`
+and discrete widgets (`mo.ui.slider(steps=[...])`,
+`mo.ui.dropdown(options=[...])`, `mo.ui.switch()`,
+`mo.ui.checkbox()`, `mo.ui.radio(options=[...])`) get real
+client-side interactivity backed by build-time per-value rendering —
+no Python kernel at runtime. Caps cap compute time and bundle size;
+v1 supports single-widget pages.
 
 ### Added — static reactivity execution (2/2)
 


### PR DESCRIPTION
Tiny release-prep PR. Renames the `[Unreleased]` sections to `[0.1.0a5] — 2026-04-25`. After merge, cut tag `v0.1.0a5` to publish the static-reactivity feature (PR #6 + PR #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)