### PR TITLE
Precompute: handle slider with all-kwargs (start=, stop=, step=)

### DIFF
--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -164,31 +164,24 @@ def _slider_values(args: list[ast.expr], kwargs: dict[str, ast.expr]) -> list[An
 
     Recognised forms (all with literal numeric arguments):
 
-    - ``mo.ui.slider(steps=[a, b, c, ...])``   — explicit list
-    - ``mo.ui.slider(start, stop, step=N)``    — explicit step kwarg
-    - ``mo.ui.slider(start, stop, step)``      — three positional args
+    - ``mo.ui.slider(steps=[a, b, c, ...])``         — explicit list
+    - ``mo.ui.slider(start, stop, step=N)``          — start/stop positional, step kwarg
+    - ``mo.ui.slider(start, stop, step)``            — three positional args
+    - ``mo.ui.slider(start=A, stop=B, step=N)``      — all kwargs (marimo's recommended style)
 
-    Everything else (``mo.ui.slider(start, stop)`` with no step) is
-    continuous and skipped.
+    Everything else (``mo.ui.slider(start, stop)`` with no step,
+    ``mo.ui.slider(start=A, stop=B)`` with no step) is continuous and
+    skipped.
     """
     if "steps" in kwargs:
         return _list_kwarg(kwargs, "steps")
 
-    # Need start, stop, AND step (positional or kwarg).
-    if len(args) >= 3:
-        start, stop, step = (
-            _literal_or_none(args[0]),
-            _literal_or_none(args[1]),
-            _literal_or_none(args[2]),
-        )
-    elif len(args) == 2 and "step" in kwargs:
-        start, stop, step = (
-            _literal_or_none(args[0]),
-            _literal_or_none(args[1]),
-            _literal_or_none(kwargs["step"]),
-        )
-    else:
+    # Resolve start/stop/step from any combination of positional + kwarg.
+    # marimo's signature is `slider(start=None, stop=None, step=None, ...)`.
+    raw = _resolve_slider_bounds(args, kwargs)
+    if raw is None:
         return None  # continuous — opt out
+    start, stop, step = raw
 
     if not all(isinstance(v, (int, float)) for v in (start, stop, step)):
         return None
@@ -197,6 +190,27 @@ def _slider_values(args: list[ast.expr], kwargs: dict[str, ast.expr]) -> list[An
 
     # Inclusive of stop, like marimo's slider semantics.
     return _arange_inclusive(start, stop, step)
+
+
+def _resolve_slider_bounds(
+    args: list[ast.expr], kwargs: dict[str, ast.expr]
+) -> tuple[Any, Any, Any] | None:
+    """Return ``(start, stop, step)`` literals from any arg arrangement, or None."""
+    # Positional args fill start/stop/step in order.
+    positional = [_literal_or_none(a) for a in args[:3]]
+    # Kwargs override / fill in the gaps.
+    start = positional[0] if len(positional) >= 1 else None
+    stop = positional[1] if len(positional) >= 2 else None
+    step = positional[2] if len(positional) >= 3 else None
+    if "start" in kwargs:
+        start = _literal_or_none(kwargs["start"])
+    if "stop" in kwargs:
+        stop = _literal_or_none(kwargs["stop"])
+    if "step" in kwargs:
+        step = _literal_or_none(kwargs["step"])
+    if start is None or stop is None or step is None:
+        return None
+    return start, stop, step
 
 
 def _arange_inclusive(start: float, stop: float, step: float) -> list[Any]:

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -70,6 +70,29 @@ def test_slider_zero_step_skipped() -> None:
     assert _scan("s = mo.ui.slider(0, 10, step=0)") == []
 
 
+def test_slider_with_all_kwargs() -> None:
+    """marimo's recommended style: `slider(start=A, stop=B, step=N)`."""
+    cands = _scan("s = mo.ui.slider(start=0, stop=10, step=2)")
+    assert len(cands) == 1
+    assert cands[0].values == [0, 2, 4, 6, 8, 10]
+
+
+def test_slider_all_kwargs_no_step_is_continuous() -> None:
+    assert _scan("s = mo.ui.slider(start=0, stop=10)") == []
+
+
+def test_slider_all_kwargs_with_value_default() -> None:
+    cands = _scan("s = mo.ui.slider(start=0, stop=4, step=1, value=2)")
+    assert cands[0].values == [0, 1, 2, 3, 4]
+    assert cands[0].default == 2
+
+
+def test_slider_kwargs_with_extra_marimo_kwargs() -> None:
+    """dartbrains-style: includes label, value, etc. We ignore the extras."""
+    cands = _scan('s = mo.ui.slider(start=-15, stop=15, step=5, value=0, label="Translate X")')
+    assert cands[0].values == [-15, -10, -5, 0, 5, 10, 15]
+
+
 # --- dropdown --------------------------------------------------------------
 
 


### PR DESCRIPTION
Found while testing v0.1.0a5 on dartbrains. The AST scanner only recognised \`mo.ui.slider(start, stop, step=N)\` (positional start/stop) and missed \`mo.ui.slider(start=A, stop=B, step=N)\` — marimo's own recommended style and what dartbrains uses everywhere.

Refactored \`_slider_values\` to delegate to a new \`_resolve_slider_bounds\` helper that fills start/stop/step from any combination of positional + kwarg arguments. The continuous-slider opt-out rule still applies: both stop AND step must be present (positional or kwarg) for a candidate to register; missing step → continuous → render static.

## Tests (4 new, 102/102 passing)

- all-kwargs basic (\`start=A, stop=B, step=N\`)
- all-kwargs no step → continuous
- all-kwargs with \`value=\` default
- dartbrains-style with extra kwargs (\`label=\"...\"\`)

## Real-world signal

Without this fix, *every* dartbrains slider would have been silently ignored by the precompute scanner — the warnings I added in v0.1.0a5 (\"X widgets found, v1 supports single-widget pages only\") would never have fired for those pages. dartbrains would have shown precompute as broken-by-omission rather than with a clear v1-limitation explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)