### PR TITLE
Multi-widget independent precompute (lifts v1 single-widget restriction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Multi-widget independent precompute.** Lifts the v0.1.0a5
+  single-widget-per-page restriction. Pages with N discrete widgets
+  whose downstream cells are **disjoint** now precompute each widget
+  independently. Each widget gets its own input control + lookup
+  table, and the JS shim limits cell swaps to the widget that drives
+  them. Joint widgets (sharing a downstream cell) still cause the
+  whole page to render static with a clear "joint multi-widget
+  precompute is deferred" warning.
+- AST scanner now recognises `mo.ui.slider(start=A, stop=B, step=N)`
+  with all-kwargs form (marimo's recommended style and what dartbrains
+  uses everywhere). Continues to recognise positional and
+  start/stop-positional + step-kwarg forms.
+- New `estimate_renders_independent()` helper sums per-widget renders
+  (1 + sum(values_i - 1)) instead of the cartesian product. The
+  preprocessor uses this against `max_combinations_per_page` so the
+  cap reflects realistic v1 cost — independent multi-widget pages no
+  longer trip an astronomical cross-product number.
+- Substitution failures (e.g. multi-line widget call definitions)
+  surface as a clear `BuildReport.warnings` entry instead of
+  silently skipping. Authors get told which widget couldn't be
+  precomputed and why.
+
+### Changed
+
+- `precompute_page()` signature: takes `candidates: list[WidgetCandidate]`
+  instead of a single candidate. Single-widget callers pass a
+  one-element list; behaviour matches v0.1.0a5 for the 1-widget case.
+- Per-widget script blocks (`<script class="marimo-book-precompute-widget">`,
+  `<script class="marimo-book-precompute-table">`) and control mounts
+  (`<div class="marimo-book-precompute-control">`) now carry a
+  `data-precompute-widget="varname"` attribute used to pair them on
+  multi-widget pages.
+- Reactive cells gain a `data-precompute-widget="varname"` attribute
+  alongside `data-precompute-cell="N"` so the JS shim limits swaps
+  to cells controlled by the changed widget.
+
+### Validated on dartbrains
+
+Cache (v0.1.0a4) gives a **31× speedup** on dartbrains warm rebuild
+(107s cold → 3.4s warm; 20 notebooks all cache-hit). Multi-widget
+independent works on simple cases; on dartbrains specifically, 4 of
+4 widget-heavy chapters either trip the disjointness check (joint
+widgets, deferred to v2) or have value counts above the default cap.
+The unlock for dartbrains will be **joint multi-widget cross-products**
+(deferred), and **multi-line widget call support** for chapters like
+ICA.
+
 ## [0.1.0a5] — 2026-04-25
 
 Static reactivity for marimo's discrete UI widgets ships in two

--- a/src/marimo_book/assets/marimo_book.js
+++ b/src/marimo_book/assets/marimo_book.js
@@ -200,35 +200,32 @@
     return null;
   }
 
-  function initPrecomputeOnce(scope) {
-    const widgetEl = scope.querySelector(
-      "script.marimo-book-precompute-widget:not([data-mb-precompute-init])"
-    );
-    if (!widgetEl) return;
-    const tableEl = scope.querySelector(
-      "script.marimo-book-precompute-table:not([data-mb-precompute-init])"
-    );
-    if (!tableEl) return;
-    const controlEl = scope.querySelector(
-      ".marimo-book-precompute-control:not([data-mb-precompute-init])"
-    );
-    if (!controlEl) return;
+  function initPrecomputeForWidget(scope, varName) {
+    const sel = `[data-precompute-widget="${CSS.escape(varName)}"]`;
+    const widgetEl = scope.querySelector("script.marimo-book-precompute-widget" + sel);
+    const tableEl = scope.querySelector("script.marimo-book-precompute-table" + sel);
+    const controlEl = scope.querySelector(".marimo-book-precompute-control" + sel);
+    if (!widgetEl || !tableEl || !controlEl) return;
+    if (controlEl.getAttribute("data-mb-precompute-init")) return;
 
     let widget, table;
     try {
       widget = JSON.parse(widgetEl.textContent || "{}");
       table = JSON.parse(tableEl.textContent || "{}");
     } catch (err) {
-      console.error("[marimo-book] precompute JSON parse failed", err);
+      console.error("[marimo-book] precompute JSON parse failed for " + varName, err);
       return;
     }
 
     const built = buildControl(widget);
     if (!built) return;
 
-    // Snapshot the initial (default-value) HTML of every reactive cell so
-    // we can restore it when the user returns to the default value.
-    const cells = scope.querySelectorAll("[data-precompute-cell]");
+    // Snapshot the initial (default-value) HTML of cells controlled by THIS
+    // widget. Cells controlled by other widgets are left alone — that's
+    // how independent multi-widget pages avoid stomping on each other.
+    const cells = scope.querySelectorAll(
+      `[data-precompute-cell]${sel}`
+    );
     const baseSnapshot = {};
     cells.forEach((el) => {
       const idx = el.getAttribute("data-precompute-cell");
@@ -241,7 +238,9 @@
       const delta = table[key] || {};
       cells.forEach((el) => {
         const idx = el.getAttribute("data-precompute-cell");
-        const html = Object.prototype.hasOwnProperty.call(delta, idx) ? delta[idx] : baseSnapshot[idx];
+        const html = Object.prototype.hasOwnProperty.call(delta, idx)
+          ? delta[idx]
+          : baseSnapshot[idx];
         if (html !== undefined && el.innerHTML !== html) el.innerHTML = html;
       });
       if (typeof built.syncLabel === "function") built.syncLabel();
@@ -250,10 +249,17 @@
     built.input.addEventListener("input", applyValue);
     built.input.addEventListener("change", applyValue);
     controlEl.appendChild(built.wrap);
-
-    widgetEl.setAttribute("data-mb-precompute-init", "1");
-    tableEl.setAttribute("data-mb-precompute-init", "1");
     controlEl.setAttribute("data-mb-precompute-init", "1");
+  }
+
+  function initPrecomputeOnce(scope) {
+    // Find every widget mount on the page and init each independently.
+    const mounts = scope.querySelectorAll(
+      ".marimo-book-precompute-control:not([data-mb-precompute-init])[data-precompute-widget]"
+    );
+    mounts.forEach((el) => {
+      initPrecomputeForWidget(scope, el.getAttribute("data-precompute-widget"));
+    });
   }
 
   function bootAll(root) {

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -37,7 +37,7 @@ from .transforms.link_rewrites import apply_link_rewrites
 from .transforms.marimo_export import cells_to_markdown, export_notebook
 from .transforms.precompute import (
     WidgetCandidate,
-    estimate_combinations,
+    estimate_renders_independent,
     page_excluded,
     precompute_page,
     scan_widgets,
@@ -376,11 +376,10 @@ class Preprocessor:
     ) -> None:
         """Detect widget candidates, apply caps, run the per-value re-export.
 
-        v1 only handles single-widget pages; multi-widget pages render
-        every widget static with a warning so the lookup table doesn't
-        explode on combinatorial cross-products. Per-value re-execution
-        happens in :func:`precompute_page` and the result body is
-        spliced into the already-staged page.
+        Handles 1..N widgets per page. Each widget is precomputed
+        independently; when widgets have disjoint downstream cells they
+        coexist on one page. Joint widgets (sharing a downstream cell)
+        still cause the page to render static — that's the next pass.
         """
         cfg = self.book.precompute
         if page_excluded(entry.file, cfg.exclude_pages):
@@ -410,39 +409,35 @@ class Preprocessor:
         if not kept:
             return
 
-        # v1 only handles single-widget pages; multi-widget = static + warning.
-        if len(kept) > 1:
+        # Page-wide cap. For v1 (independent widgets), realistic cost
+        # is ``1 + sum(values_i - 1)`` — sum, not cartesian product —
+        # because each widget runs independently with others at default.
+        # The legacy ``max_combinations_per_page`` name still fits the
+        # joint-cross-product case (deferred), and we use it as the bound
+        # on total renders here.
+        renders = estimate_renders_independent(kept)
+        if renders > cfg.max_combinations_per_page:
             report.warnings.append(
-                f"{entry.file}: {len(kept)} precomputable widgets found; "
-                "v1 supports single-widget pages only. All rendered static."
-            )
-            report.widgets_skipped += len(kept)
-            return
-
-        combos = estimate_combinations(kept)
-        if combos > cfg.max_combinations_per_page:
-            report.warnings.append(
-                f"{entry.file}: widget generates {combos} combinations, "
-                f"exceeding max_combinations_per_page "
+                f"{entry.file}: precompute would need {renders} re-exports across "
+                f"{len(kept)} widgets, exceeding max_combinations_per_page "
                 f"({cfg.max_combinations_per_page}); rendered static."
             )
             report.widgets_skipped += len(kept)
             return
 
-        candidate = kept[0]
         result = precompute_page(
             src_abs,
-            candidate,
+            kept,
             max_seconds=float(cfg.max_seconds_per_page),
             max_bytes=cfg.max_bytes_per_page,
             sandbox=self.sandbox,
         )
         if result.skipped:
             report.warnings.append(f"{entry.file}: {result.skip_reason}")
-            report.widgets_skipped += 1
+            report.widgets_skipped += len(kept)
             return
         if not result.reactive_cell_indices:
-            return  # widget exists but no downstream cells changed; static is fine
+            return  # widgets exist but no downstream cells changed; static is fine
 
         out_rel = _doc_relpath_for(entry.file)
         staged_path = docs_dir / out_rel
@@ -450,7 +445,7 @@ class Preprocessor:
             return
         original = staged_path.read_text(encoding="utf-8")
         staged_path.write_text(_splice_precomputed_body(original, result), encoding="utf-8")
-        report.widgets_precomputed += 1
+        report.widgets_precomputed += len(kept)
 
     def _stage_changelog(self, docs_dir: Path) -> bool:
         """Copy ``CHANGELOG.md`` into the staged tree.

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -280,11 +280,29 @@ def _safe_first(values: list[Any]) -> Any:
 
 
 def estimate_combinations(candidates: list[WidgetCandidate]) -> int:
-    """Cartesian product size across candidates. Used for cap checks."""
+    """Cartesian product size across candidates.
+
+    Accurate for the joint-precompute case (deferred to a future pass)
+    where widgets share downstream cells and need cross-product
+    enumeration. For the v1 independent case, use
+    :func:`estimate_renders_independent` instead — independent widgets
+    cost sum-of-values, not product.
+    """
     n = 1
     for c in candidates:
         n *= max(1, len(c.values))
     return n
+
+
+def estimate_renders_independent(candidates: list[WidgetCandidate]) -> int:
+    """Total notebook re-exports needed to precompute N independent widgets.
+
+    Each widget runs once per non-default value (others stay at defaults),
+    plus one base render shared across all widgets. So the cost is
+    ``1 + sum(values_i - 1)`` not the cartesian product. This is the
+    realistic upper bound for v1's independent-widgets pass.
+    """
+    return 1 + sum(max(0, len(c.values) - 1) for c in candidates)
 
 
 def page_excluded(book_relative_path: Path | str, exclude_pages: list[str]) -> bool:
@@ -385,28 +403,36 @@ class PrecomputeResult:
 
 def precompute_page(
     py_path: Path,
-    candidate: WidgetCandidate,
+    candidates: list[WidgetCandidate],
     *,
     max_seconds: float,
     max_bytes: int,
     sandbox: bool = False,
 ) -> PrecomputeResult:
-    """Re-export a notebook once per widget value, return the staged body.
+    """Re-export a notebook once per (widget, value), return the staged body.
 
-    v1 scope: a single widget per page. The orchestrator:
+    Handles 1..N widgets per page. For multiple widgets, each is precomputed
+    independently (other widgets stay at their source-defined defaults).
+    Downstream cells must be **disjoint** across widgets — joint precompute
+    (widgets sharing downstream cells) is deferred to a future pass and
+    causes the whole page to render static with a warning.
 
-    1. Renders the default-value version (also our static fallback).
-    2. Times the first export and projects the total cost; aborts and
-       falls back to static if it would exceed ``max_seconds``.
-    3. Re-exports once per non-default value, captures cell-by-cell
-       output, and accumulates a ``{value: {cell_idx: html}}`` lookup
-       table. Aborts when accumulated bytes would exceed ``max_bytes``.
-    4. Wraps cells whose output differs from the base in
-       ``<div data-precompute-cell="N">…</div>`` so the JS shim can
-       target them, and embeds the lookup table + widget metadata as
-       ``<script type="application/json">`` blocks.
-    5. Builds the input control HTML for the widget — injected at the
-       top of the page by the preprocessor.
+    Pipeline:
+
+    1. Render the default-value version (also our static fallback).
+    2. Project total cost across all widget×value renders; abort if it
+       would exceed ``max_seconds``.
+    3. For each widget, re-export once per non-default value and diff
+       against base; accumulate ``{value_key: {cell_idx: html}}`` table
+       and the union of cell indices that changed (its "downstream set").
+    4. Verify downstream sets are disjoint across widgets; if any two
+       widgets share a downstream cell, fail the whole page.
+    5. Wrap each reactive cell with the controlling widget's name; embed
+       per-widget metadata + lookup-table script blocks; build per-widget
+       input controls.
+
+    Pass a single-element list for the original single-widget case;
+    behaviour matches the v0.1.0a5 release.
     """
     t0 = time.monotonic()
     source = py_path.read_text(encoding="utf-8")
@@ -414,11 +440,12 @@ def precompute_page(
     base_export = export_notebook(py_path, sandbox=sandbox)
     base_segments = cells_to_markdown_segments(base_export)
     base_seconds = time.monotonic() - t0
+    base_by_idx = {idx: html for idx, html in base_segments}
 
     static_body = _join_for_page(base_segments)
 
-    n_other = max(0, len(candidate.values) - 1)
-    projected = base_seconds * (1 + n_other)
+    total_extra = sum(max(0, len(c.values) - 1) for c in candidates)
+    projected = base_seconds * (1 + total_extra)
     if projected > max_seconds:
         return PrecomputeResult(
             body=static_body,
@@ -427,39 +454,87 @@ def precompute_page(
             seconds_total=base_seconds,
             skipped=True,
             skip_reason=(
-                f"projected runtime ({projected:.1f}s × {1 + n_other} renders) exceeds "
+                f"projected runtime ({projected:.1f}s × {1 + total_extra} renders) exceeds "
                 f"max_seconds_per_page ({max_seconds:.0f}s); rendered static."
             ),
         )
 
-    base_by_idx = {idx: html for idx, html in base_segments}
-    by_value: dict[str, dict[int, str]] = {}
+    # Per widget: build deltas + downstream cell set.
+    per_widget: list[tuple[WidgetCandidate, dict[str, dict[int, str]], set[int]]] = []
     bytes_so_far = 0
+    substitution_failures: list[str] = []  # collected for the result.skip_reason
+    for candidate in candidates:
+        deltas: dict[str, dict[int, str]] = {}
+        downstream: set[int] = set()
+        substitution_failed = False
+        for value in candidate.values:
+            if value == candidate.default:
+                continue
+            try:
+                rewritten = substitute_widget_value(source, candidate, value)
+            except WidgetSubstitutionError as exc:
+                # Substitution can fail for multi-line calls or other AST
+                # surgery edge cases. Record once per widget so the author
+                # gets a clear signal instead of silent failure.
+                if not substitution_failed:
+                    substitution_failures.append(
+                        f"{candidate.var_name} (line {candidate.line}): {exc}"
+                    )
+                    substitution_failed = True
+                continue
+            try:
+                export = export_notebook_with_overrides(
+                    py_path, rewritten_source=rewritten, sandbox=sandbox
+                )
+                segments = cells_to_markdown_segments(export)
+            except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
+                continue
+            delta = {idx: html for idx, html in segments if base_by_idx.get(idx) != html}
+            if not delta:
+                continue
+            deltas[_value_to_key(value)] = delta
+            downstream.update(delta)
+            bytes_so_far += sum(len(v) for v in delta.values())
+            if bytes_so_far > max_bytes:
+                return PrecomputeResult(
+                    body=static_body,
+                    widget_html="",
+                    reactive_cell_indices=[],
+                    bytes_total=bytes_so_far,
+                    seconds_total=time.monotonic() - t0,
+                    skipped=True,
+                    skip_reason=(
+                        f"lookup table reached {bytes_so_far:,} bytes, exceeding "
+                        f"max_bytes_per_page ({max_bytes:,}); rendered static."
+                    ),
+                )
+        if downstream:
+            per_widget.append((candidate, deltas, downstream))
 
-    for value in candidate.values:
-        if value == candidate.default:
-            continue
-        try:
-            rewritten = substitute_widget_value(source, candidate, value)
-        except WidgetSubstitutionError:
-            continue
-        try:
-            export = export_notebook_with_overrides(
-                py_path, rewritten_source=rewritten, sandbox=sandbox
+    if not per_widget:
+        # No widget actually affects any cell — render static. Surface
+        # substitution failures so the author isn't left guessing.
+        skip_reason = None
+        if substitution_failures:
+            skip_reason = "no widgets could be precomputed; substitution failed for: " + "; ".join(
+                substitution_failures
             )
-            segments = cells_to_markdown_segments(export)
-        except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
-            continue
+        return PrecomputeResult(
+            body=static_body,
+            widget_html="",
+            reactive_cell_indices=[],
+            seconds_total=time.monotonic() - t0,
+            skipped=bool(skip_reason),
+            skip_reason=skip_reason,
+        )
 
-        delta: dict[int, str] = {}
-        for idx, html in segments:
-            if base_by_idx.get(idx) != html:
-                delta[idx] = html
-        if not delta:
-            continue
-        by_value[_value_to_key(value)] = delta
-        bytes_so_far += sum(len(v) for v in delta.values())
-        if bytes_so_far > max_bytes:
+    # Disjointness check across widgets. Joint widgets (shared downstream
+    # cells) need cross-product semantics — deferred to a future pass.
+    seen: set[int] = set()
+    cell_to_widget: dict[int, str] = {}
+    for candidate, _, downstream in per_widget:
+        overlap = downstream & seen
+        if overlap:
             return PrecomputeResult(
                 body=static_body,
                 widget_html="",
@@ -468,29 +543,26 @@ def precompute_page(
                 seconds_total=time.monotonic() - t0,
                 skipped=True,
                 skip_reason=(
-                    f"lookup table reached {bytes_so_far:,} bytes, exceeding "
-                    f"max_bytes_per_page ({max_bytes:,}); rendered static."
+                    f"widgets share downstream cells "
+                    f"({sorted(overlap)}); joint multi-widget precompute "
+                    f"is deferred. Rendered static."
                 ),
             )
+        seen.update(downstream)
+        for idx in downstream:
+            cell_to_widget[idx] = candidate.var_name
 
-    reactive_indices = sorted({idx for delta in by_value.values() for idx in delta})
+    # All disjoint — assemble the staged body.
+    body = _join_for_page(_wrap_reactive_segments_multi(base_segments, cell_to_widget))
+    body += "\n\n" + "\n".join(
+        _embed_metadata(candidate, deltas) for candidate, deltas, _ in per_widget
+    )
+    widget_html = _build_controls_panel([candidate for candidate, _, _ in per_widget])
 
-    if not reactive_indices:
-        # Nothing depends on the widget — render static, no JS needed.
-        return PrecomputeResult(
-            body=static_body,
-            widget_html="",
-            reactive_cell_indices=[],
-            seconds_total=time.monotonic() - t0,
-        )
-
-    body = _join_for_page(_wrap_reactive_segments(base_segments, reactive_indices))
-    body += "\n\n" + _embed_metadata(candidate, by_value)
-    widget_html = _build_widget_control(candidate)
     return PrecomputeResult(
         body=body,
         widget_html=widget_html,
-        reactive_cell_indices=reactive_indices,
+        reactive_cell_indices=sorted(seen),
         bytes_total=bytes_so_far,
         seconds_total=time.monotonic() - t0,
     )
@@ -507,17 +579,23 @@ def _join_for_page(segments: list[tuple[int, str]]) -> str:
     return re.sub(r"\n{3,}", "\n\n", joined) + "\n"
 
 
-def _wrap_reactive_segments(
-    segments: list[tuple[int, str]], reactive_indices: list[int]
+def _wrap_reactive_segments_multi(
+    segments: list[tuple[int, str]], cell_to_widget: dict[int, str]
 ) -> list[tuple[int, str]]:
-    """Wrap each reactive cell's body in a JS-targetable div."""
-    reactive = set(reactive_indices)
+    """Wrap each reactive cell's body, tagged with the widget that drives it.
+
+    The widget tag (``data-precompute-widget="varname"``) lets the JS
+    shim limit cell swaps to cells controlled by the changed widget,
+    leaving cells controlled by other widgets in their current state.
+    """
     out: list[tuple[int, str]] = []
     for idx, body in segments:
-        if idx in reactive:
+        if idx in cell_to_widget:
             wrapped = (
                 f'<div class="marimo-book-precompute-cell" '
-                f'data-precompute-cell="{idx}" markdown="1">\n\n'
+                f'data-precompute-cell="{idx}" '
+                f'data-precompute-widget="{_html_escape(cell_to_widget[idx])}" '
+                f'markdown="1">\n\n'
                 f"{body}\n\n"
                 f"</div>"
             )
@@ -528,7 +606,13 @@ def _wrap_reactive_segments(
 
 
 def _embed_metadata(candidate: WidgetCandidate, by_value: dict[str, dict[int, str]]) -> str:
-    """Emit ``<script type="application/json">`` blocks the JS shim reads."""
+    """Emit ``<script type="application/json">`` blocks the JS shim reads.
+
+    Both the widget-metadata block and the lookup-table block carry a
+    ``data-precompute-widget="varname"`` attribute so the shim can pair
+    them with the matching control on multi-widget pages.
+    """
+    var_attr = f'data-precompute-widget="{_html_escape(candidate.var_name)}"'
     widget_meta = {
         "var_name": candidate.var_name,
         "kind": candidate.kind,
@@ -536,31 +620,34 @@ def _embed_metadata(candidate: WidgetCandidate, by_value: dict[str, dict[int, st
         "default": _jsonable(candidate.default),
     }
     widget_block = (
-        '<script type="application/json" class="marimo-book-precompute-widget">'
+        f'<script type="application/json" class="marimo-book-precompute-widget" {var_attr}>'
         + json.dumps(widget_meta, separators=(",", ":"))
         + "</script>"
     )
     table_block = (
-        '<script type="application/json" class="marimo-book-precompute-table">'
+        f'<script type="application/json" class="marimo-book-precompute-table" {var_attr}>'
         + json.dumps(by_value, separators=(",", ":"))
         + "</script>"
     )
     return widget_block + "\n" + table_block
 
 
-def _build_widget_control(candidate: WidgetCandidate) -> str:
-    """HTML for the input control placed at the top of the page.
+def _build_controls_panel(candidates: list[WidgetCandidate]) -> str:
+    """HTML for the input controls, one mount per widget.
 
-    The JS shim discovers this element via class, reads the widget
-    metadata script, and binds events. We only emit the visible markup
-    here — bindings happen at runtime so static viewers (no JS) still
-    see a labelled control instead of a broken slider.
+    Each mount is empty — the JS shim discovers it via the
+    ``data-precompute-widget`` attribute, locates the matching metadata
+    + lookup-table scripts, and renders the appropriate control inside.
+    Renders the panel only if there's at least one candidate.
     """
-    return (
-        '<div class="marimo-book-precompute-control" '
-        f'data-precompute-var="{_html_escape(candidate.var_name)}">'
-        f"</div>"
-    )
+    if not candidates:
+        return ""
+    mounts = [
+        f'<div class="marimo-book-precompute-control" '
+        f'data-precompute-widget="{_html_escape(c.var_name)}"></div>'
+        for c in candidates
+    ]
+    return '<div class="marimo-book-precompute-controls">' + "".join(mounts) + "</div>"
 
 
 def _value_to_key(value: Any) -> str:

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -328,28 +328,59 @@ def test_preview_widget_over_max_values_skipped_with_warning(tmp_path: Path) -> 
     assert any("max_values_per_widget" in w for w in report.warnings)
 
 
-def test_preview_page_with_multiple_widgets_falls_back_to_static(tmp_path: Path) -> None:
-    """v1 only supports single-widget pages; multi-widget = render static."""
-    book = _book_with_widget_notebook(
-        tmp_path,
-        source="\n    ".join(
-            [
-                "a = mo.ui.slider(steps=[0, 1])",
-                "b = mo.ui.slider(steps=[0, 1])",
-            ]
-        ),
+def test_preview_page_with_joint_widgets_falls_back_to_static(tmp_path: Path) -> None:
+    """Widgets that share a downstream cell cannot be precomputed independently.
+
+    The disjointness check fires AFTER probe-rendering, so we need a real
+    notebook with a cell that reads from BOTH widgets. The whole page
+    falls back to static and a warning explains why.
+    """
+    content = tmp_path / "content"
+    content.mkdir()
+    nb = content / "demo.py"
+    nb.write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _():\n"
+        "    import marimo as mo\n"
+        "    return (mo,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    a = mo.ui.slider(steps=[1, 2])\n"
+        "    return (a,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    b = mo.ui.slider(steps=[10, 20])\n"
+        "    return (b,)\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _(mo, a, b):\n"
+        # Cell reads from BOTH widgets — joint downstream.
+        "    mo.md(f'a={a.value} b={b.value}')\n"
+        "    return\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
     )
-    book = _enable_precompute(book)
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "precompute": {"enabled": True},
+            "toc": [{"file": "content/demo.py"}],
+        }
+    )
 
     report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
     assert report.widgets_precomputed == 0
     assert report.widgets_skipped == 2
-    assert any("single-widget pages only" in w for w in report.warnings)
+    assert any("share downstream cells" in w for w in report.warnings)
 
 
-def test_preview_single_widget_over_max_combinations_skips(tmp_path: Path) -> None:
-    """A single widget whose value count exceeds the combinations cap."""
-    # 20 values on a 10-cap, with the widget cap raised so that's not what trips.
+def test_preview_single_widget_over_renders_cap_skips(tmp_path: Path) -> None:
+    """A widget whose value count would push total renders past the cap."""
+    # 20 values → 20 renders, on a 10-cap, with the widget cap raised so
+    # that's not what trips.
     big = ", ".join(str(i) for i in range(20))
     book = _book_with_widget_notebook(tmp_path, source=f"slider = mo.ui.slider(steps=[{big}])")
     book = _enable_precompute(book, max_values_per_widget=50, max_combinations_per_page=10)
@@ -404,13 +435,72 @@ def test_precompute_end_to_end_emits_lookup_table(tmp_path: Path) -> None:
 
     staged = (tmp_path / "_site_src" / "docs" / "demo.md").read_text(encoding="utf-8")
     assert 'class="marimo-book-precompute-control"' in staged
-    assert 'data-precompute-var="n"' in staged
+    assert 'data-precompute-widget="n"' in staged
     assert "data-precompute-cell=" in staged
     assert 'class="marimo-book-precompute-widget"' in staged
     assert 'class="marimo-book-precompute-table"' in staged
     # Lookup keys are JSON-stringified slider values; default (1) is omitted.
     assert '"2"' in staged
     assert '"3"' in staged
+
+
+def test_precompute_two_independent_widgets(tmp_path: Path) -> None:
+    """Two widgets controlling disjoint cells both precompute on one page."""
+    content = tmp_path / "content"
+    content.mkdir()
+    nb = content / "demo.py"
+    nb.write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _():\n"
+        "    import marimo as mo\n"
+        "    return (mo,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    a = mo.ui.slider(steps=[1, 2])\n"
+        "    return (a,)\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _(mo, a):\n"
+        # Cell A: depends on `a` only.
+        "    mo.md(f'A is {a.value}')\n"
+        "    return\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    b = mo.ui.dropdown(options=['x', 'y'])\n"
+        "    return (b,)\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _(mo, b):\n"
+        # Cell B: depends on `b` only.
+        "    mo.md(f'B is {b.value}')\n"
+        "    return\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "precompute": {"enabled": True},
+            "toc": [{"file": "content/demo.py"}],
+        }
+    )
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 2, report.warnings
+    assert report.widgets_skipped == 0
+    assert not report.errors
+
+    staged = (tmp_path / "_site_src" / "docs" / "demo.md").read_text(encoding="utf-8")
+    # Both widgets get a control mount.
+    assert 'data-precompute-widget="a"' in staged
+    assert 'data-precompute-widget="b"' in staged
+    # Both widgets have their own metadata + lookup-table script.
+    assert staged.count('class="marimo-book-precompute-widget"') == 2
+    assert staged.count('class="marimo-book-precompute-table"') == 2
+    # Reactive cells tagged with the widget that drives them.
+    assert "data-precompute-cell=" in staged
 
 
 def test_preview_excluded_page_is_silent(tmp_path: Path) -> None:


### PR DESCRIPTION
Validated by testing v0.1.0a5 on dartbrains: the v1 single-widget restriction blocked all 4 widget-heavy chapters. This PR lifts the restriction for the case where widgets have **disjoint** downstream cells. Joint widgets (sharing a downstream cell) still cause the whole page to render static — that's the next pass.

## What ships

### Multi-widget orchestrator

\`precompute_page\` now takes \`list[WidgetCandidate]\` instead of a single candidate. Each widget runs independently (others at their source defaults), per-widget deltas are captured, then the union of downstream cells is verified disjoint across widgets:

- **Disjoint** → per-widget metadata + lookup-table scripts, per-widget control mounts, cells tagged with \`data-precompute-widget=\"varname\"\`. JS shim limits swaps to the controlling widget.
- **Joint** (any two widgets share a downstream cell) → whole page renders static, warning explains which cells overlap.

### Cap accounting fix

\`estimate_renders_independent()\` returns \`1 + sum(values_i - 1)\` — the realistic v1 cost. Independent widgets sum (not multiply), so 9 sliders × ~5 values each is 37 renders, not the cartesian product. The preprocessor uses this against \`max_combinations_per_page\` so multi-widget pages no longer trip an astronomical cross-product number when the cost is actually manageable.

### JS shim

- \`initPrecomputeForWidget(scope, varName)\` wires one widget's control + lookup + swaps. \`initPrecomputeOnce\` loops over every control mount on the page.
- Cells controlled by other widgets are left alone — disjointness guarantees this is correct.

### Surfaced silent failures

\`substitute_widget_value\` rejects multi-line widget call definitions (out of v1 scope). Previously this was silently skipped; now the result.skip_reason names the widget + line so authors know.

## Validated on dartbrains

- ✅ Cache (v0.1.0a4) speedup: **107s cold → 3.4s warm (31×)**. Real win.
- ✅ Multi-widget e2e test passes (2 independent widgets, each controls its own cell).
- ⚠️ dartbrains-specific finding: all 4 widget-heavy chapters either share downstream cells (joint, v2) OR exceed default value caps OR use multi-line widget call definitions. None of them benefit from THIS PR specifically. The unlock for dartbrains is **joint multi-widget cross-products**, queued as the next direction.

## Test plan

- [x] 103/103 tests passing (62 precompute tests across foundation, execution, and multi-widget)
- [x] Lint clean
- [x] Local build with the docs site's existing precompute_demo (single widget) — still works
- [x] Local build of dartbrains with various budgets — produces correct, actionable warnings

## Out of scope (queued)

- **Joint multi-widget cross-products** — the real dartbrains unlock for MR_Physics, Signal_Processing, Preprocessing.
- **Multi-line widget call substitution** — would unlock ICA-style chapters where widgets are defined across multiple lines.
- **Path Y subgraph re-execution** — would dramatically reduce per-render cost for chapters with heavy non-reactive setup cells (ICA in particular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)