### PR TITLE
Date CHANGELOG for v0.1.0a6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0a6] — 2026-04-26
+
+Multi-widget reactivity + dartbrains-driven fixes. Static reactivity
+now handles independent and joint (cross-product) multi-widget pages.
+Multi-line widget call definitions are recognised. The all-kwargs
+slider style (`mo.ui.slider(start=A, stop=B, step=N)`) — marimo's
+recommended form — now produces precompute candidates. Validated by
+real testing on the dartbrains course site.
 
 ### Added — joint multi-widget + multi-line widget calls
 


### PR DESCRIPTION
Tiny release-prep PR. Renames `[Unreleased]` → `[0.1.0a6] — 2026-04-26`. After merge, cut tag `v0.1.0a6` to publish multi-widget reactivity + the all-kwargs slider fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)