### PR TITLE
WASM render mode via marimo islands (per-page opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — WASM render mode (per-page opt-in)
+
+- **`mode: wasm`** as a per-entry override in `book.yml` TOC entries.
+  When set, the page is rendered through marimo's
+  `MarimoIslandGenerator` instead of our static `cells_to_markdown`
+  pipeline. Marimo's runtime + Pyodide load in the browser at first
+  paint; cells become natively reactive, no precompute caps apply,
+  continuous sliders work as you'd expect from a real notebook.
+- `book.defaults.mode` is now widened to `Literal["static", "wasm"]`
+  for whole-book defaults; `wasm` per-entry override coexists.
+- `Book` config gains `FileEntry.effective_mode(default)` helper that
+  resolves the per-entry override against the book-wide default.
+- New module `src/marimo_book/transforms/wasm.py` with
+  `render_wasm_page()` — invokes `MarimoIslandGenerator.from_file()`,
+  awaits `build()`, returns `render_head() + render_body(style="")`
+  ready to splice into the staged page. Per-page head injection (no
+  global `extra_javascript` pollution).
+- Static reactivity (`precompute.enabled`) is automatically a no-op
+  for WASM pages — marimo's runtime handles reactivity natively, so
+  there's no point in our build-time precompute pipeline.
+- New CSS in `assets/extra.css` overriding marimo island fonts to
+  Geist (matches our static theme), suppressing per-island margins,
+  hiding marimo's loading spinner. Phase 1 styling — pixel-perfect
+  match is a polish pass.
+- New live demo chapter `docs/content/wasm_demo.py` configured with
+  `mode: wasm` in the docs site TOC. Demonstrates a continuous
+  `mo.ui.slider(1, 100)` driving live Python computation in the
+  browser — the same widget call would render as static-only on a
+  non-WASM page (no precompute candidate without an explicit step).
+
+### Asset hosting
+
+Marimo islands runtime + style are loaded from jsdelivr CDN by default
+(matches what `MarimoIslandGenerator.render_head()` emits and what we
+already do for Google Fonts + MathJax). Pyodide loads on demand from
+its own CDN inside marimo's bundle. Self-hosting is on the roadmap
+for the privacy-conscious / offline case but not yet implemented.
+
 ## [0.1.0a6] — 2026-04-26
 
 Multi-widget reactivity + dartbrains-driven fixes. Static reactivity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,10 @@ install it (the docs job needs every extra the docs site uses).
 | `check_external_links: true` | `htmlproofer` validates external URLs at build (slow; CI-only) | `marimo-book[linkcheck]` |
 | `include_changelog: true` | Preprocessor copies `CHANGELOG.md` from book root (or its parent) into the staged tree and appends a "Changelog" entry to the nav | None |
 | `pdf_export: true` | `mkdocs-with-pdf` renders the whole book to `_site/pdf/book.pdf` via WeasyPrint and adds a "Download PDF" link to the footer | `marimo-book[pdf]` (same cairo/pango system deps as `[social]`) |
-| `precompute.enabled: true` | Detects discrete `mo.ui.*` widgets (`slider` with `steps=` or explicit `step=`, `dropdown`, `switch`, `checkbox`, `radio`), re-exports the notebook per value, ships a JSON lookup table embedded in the page; JS shim swaps reactive cells on widget input. Caps in `precompute.{max_values_per_widget, max_combinations_per_page, max_seconds_per_page, max_bytes_per_page}`. v1 = single-widget pages only; multi-widget pages render static with a warning. **Will be a no-op for WASM-rendered pages when v0.2 lands** — gate point is in `Preprocessor.build()`. | None |
+| `precompute.enabled: true` | Detects discrete `mo.ui.*` widgets, re-exports per value, ships a JSON lookup table embedded in the page; JS shim swaps reactive cells on widget input. Caps in `precompute.{max_values_per_widget, max_combinations_per_page, max_seconds_per_page, max_bytes_per_page}`. Multi-widget independent + joint cross-products both supported (since v0.1.0a6). Auto-no-op on WASM pages. | None |
+| `defaults.mode: wasm` (or per-entry `mode: wasm`) | Page rendered via `MarimoIslandGenerator`. Marimo's runtime + Pyodide load in the browser; cells become natively reactive, continuous sliders work, no precompute caps. Heavy first paint (~30 MB Pyodide download, cached after first visit). Per-page opt-in is the recommended pattern — leave most pages static for fast loads, enable wasm only on chapters that need full interactivity. | None (CDN bundle from jsdelivr by default) |
 
-All six are off by default in `marimo-book new` scaffolds.
+All seven are off by default in `marimo-book new` scaffolds.
 
 ## Theme + CSS
 

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -67,6 +67,8 @@ toc:
       - file: content/authoring.md
       - file: content/example.py
       - file: content/precompute_demo.py
+      - file: content/wasm_demo.py
+        mode: wasm
       - file: content/dependencies.md
       - file: content/widgets.md
 

--- a/docs/content/wasm_demo.py
+++ b/docs/content/wasm_demo.py
@@ -1,0 +1,71 @@
+import marimo
+
+__generated_with = "0.23.3"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+        # WASM demo
+
+        This page is rendered with `mode: wasm`. Marimo's runtime loads
+        in your browser via Pyodide on first paint (one-time download
+        ~30 MB; subsequent visits are cached). Once loaded, the slider
+        below is **truly reactive** — no precomputed lookup table, no
+        caps. Drag continuously and the cell below recomputes Python
+        on each input.
+
+        Compare this with the [Static reactivity demo](precompute_demo.md),
+        which precomputes a fixed grid of values at build time and
+        ships zero Python at runtime. Both approaches have their place:
+
+        - **Static + precompute**: instant first paint, works offline,
+          tiny page, but limited to a fixed value grid declared at
+          author time. Good default.
+        - **WASM**: full Python in the browser, every cell reactive,
+          continuous sliders work, no caps. But heavy first paint and
+          requires the user's browser to download Pyodide.
+
+        Use `mode: wasm` per-page (in `book.yml`'s `toc` entry) for
+        chapters that genuinely need full reactivity. Leave the rest
+        static for fast loads.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    # Continuous slider — no precompute caps in WASM mode!
+    n = mo.ui.slider(start=1, stop=100, value=10, label="N")
+    n
+    return (n,)
+
+
+@app.cell(hide_code=True)
+def _(mo, n):
+    # Live computation in the browser — runs every time `n` changes.
+    total = sum(range(1, n.value + 1))
+    closed_form = n.value * (n.value + 1) // 2
+    mo.md(
+        f"""
+        Sum of 1..{n.value} computed live:
+
+        - Loop: **{total}**
+        - Closed form (n·(n+1)/2): **{closed_form}**
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -331,6 +331,36 @@ pre.marimo-error {
 /* Marimo callouts come through as .admonition with an extra marker class;
    no overrides needed — Material styles them. */
 
+/* --- WASM (marimo islands) integration ----------------------------------- */
+/* Override marimo's island runtime styling so it matches the book theme.
+   Marimo ships its own font stack (Lora / PT Sans / Fira Mono) and color
+   tokens; we override with our Geist + zinc palette via the `.marimo`
+   namespace. Pixel-perfect match isn't the goal; "doesn't look alien" is. */
+
+.marimo,
+marimo-island,
+marimo-cell-output {
+  font-family: var(--md-text-font), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.marimo code,
+.marimo pre,
+marimo-cell-output code,
+marimo-cell-output pre {
+  font-family: var(--md-code-font), ui-monospace, "SF Mono", Menlo, monospace;
+}
+/* Marimo's per-cell wrappers shouldn't add their own borders/padding
+   inside our content area. */
+marimo-island {
+  display: block;
+  margin: 0.75rem 0;
+}
+/* Hide marimo's loading spinner cell — it lives in the page until the
+   runtime boots, then disappears. Our cells are already visible by
+   default (server-rendered placeholder text), so the spinner is noise. */
+marimo-island[data-cell-id]:first-of-type marimo-cell-output svg.animate-spin {
+  display: none;
+}
+
 /* --- Static reactivity (precompute) -------------------------------------- */
 /* Renders for the input control + the cell-swap target. Kept minimal; sits
    inline in the page just above the first reactive cell. */

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -159,7 +159,13 @@ class Dependencies(BaseModel):
 class Defaults(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    mode: Literal["static"] = "static"  # v0.2 adds "wasm", "hybrid"
+    # ``static``  — server-rendered cell outputs (the original mode).
+    # ``wasm``    — page is rendered via marimo's islands runtime in
+    #               the browser. Pyodide loads at first paint; cells
+    #               become live and reactive without a server. Heavy
+    #               (~2 MB JS + ~30 MB Pyodide on first load); use
+    #               selectively per page rather than book-wide.
+    mode: Literal["static", "wasm"] = "static"
     hide_author_line: bool = True
     show_source_link: bool = True
     # The first code cell in a marimo notebook is, by convention, the setup /
@@ -179,8 +185,16 @@ class FileEntry(BaseModel):
 
     file: Path
     title: str | None = None
-    mode: Literal["static"] = "static"  # v0.2 adds "wasm", "hybrid"
+    # Per-entry override. ``None`` = follow ``book.defaults.mode``. Setting
+    # ``mode: wasm`` on a single ``.py`` entry routes that page through the
+    # islands renderer while every other page stays static. Markdown pages
+    # ignore this field.
+    mode: Literal["static", "wasm"] | None = None
     hidden: bool = False
+
+    def effective_mode(self, default_mode: str) -> str:
+        """Resolve this entry's render mode against the book-wide default."""
+        return self.mode or default_mode
 
 
 class UrlEntry(BaseModel):

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -42,6 +42,7 @@ from .transforms.precompute import (
     precompute_page,
     scan_widgets,
 )
+from .transforms.wasm import render_wasm_page
 
 # Directories and glob patterns of assets we copy verbatim when present.
 _ASSET_DIRS: tuple[str, ...] = ("images", "Code", "data")
@@ -330,10 +331,14 @@ class Preprocessor:
 
                 # Static-reactivity precompute: scan widgets, apply caps,
                 # re-export per value, splice the lookup table into the
-                # staged page so the JS shim can swap reactive cells.
-                # TODO(v0.2): gate on `book.defaults.mode == "static"` once
-                # WASM render mode lands — WASM pages don't need this.
-                if entry.file.suffix == ".py" and self.book.precompute.enabled:
+                # staged page so the JS shim can swap reactive cells. WASM
+                # pages get native reactivity from marimo's runtime in the
+                # browser, so precompute is a no-op for them.
+                if (
+                    entry.file.suffix == ".py"
+                    and self.book.precompute.enabled
+                    and entry.effective_mode(self.book.defaults.mode) == "static"
+                ):
                     self._run_precompute(entry, src_abs, docs_dir, report)
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{entry.file}: {exc.__class__.__name__}: {exc}")
@@ -529,16 +534,30 @@ def stage_page(
 
     buttons = render_button_row(book, Path(entry.file))
 
+    mode = entry.effective_mode(book.defaults.mode)
     if src_abs.suffix == ".py":
-        body = _render_marimo(src_abs, book, sandbox=sandbox)
+        if mode == "wasm":
+            # WASM-mode pages bypass our static cell rendering. Marimo's
+            # islands runtime takes over in the browser; the body we
+            # write here contains marimo's CDN-loaded scripts + the
+            # ``<marimo-island>`` web components for each cell.
+            body = render_wasm_page(src_abs)
+            apply_rewrites = False
+        else:
+            body = _render_marimo(src_abs, book, sandbox=sandbox)
+            apply_rewrites = True
     elif src_abs.suffix == ".md":
         body = _render_markdown(src_abs)
+        apply_rewrites = True
     else:
         raise ValueError(f"Unsupported file type for TOC entry: {entry.file}")
 
-    # Link-rewrites run after both render paths so in-notebook prose and
-    # hand-authored Markdown get the same treatment.
-    body = apply_link_rewrites(body, md_basenames=md_basenames)
+    # Link-rewrites run after both static render paths so in-notebook
+    # prose and hand-authored Markdown get the same treatment. WASM
+    # pages skip rewrites: the body is marimo's own HTML, not our
+    # Markdown — there's nothing for our rewriter to safely touch.
+    if apply_rewrites:
+        body = apply_link_rewrites(body, md_basenames=md_basenames)
 
     full = _compose_page(buttons, body)
     dst.write_text(full, encoding="utf-8")

--- a/src/marimo_book/transforms/wasm.py
+++ b/src/marimo_book/transforms/wasm.py
@@ -1,0 +1,56 @@
+"""WASM rendering via marimo's island runtime.
+
+When a TOC entry's effective mode is ``wasm`` (set via per-entry
+``mode: wasm`` in ``book.yml`` or via ``defaults.mode: wasm``), the
+preprocessor routes it through this module instead of the static
+``cells_to_markdown`` path.
+
+We use marimo's public :class:`MarimoIslandGenerator` API:
+
+1. ``MarimoIslandGenerator.from_file(py_path)`` — loads the notebook
+   and registers each cell as an island stub.
+2. ``await gen.build()`` — executes the notebook once to capture
+   initial state and HTML for each cell.
+3. ``gen.render_head()`` — produces ``<script>`` + ``<link>`` tags
+   that load marimo's frontend bundle (defaults to jsdelivr CDN; the
+   bundle in turn loads Pyodide on first paint to make cells reactive).
+4. ``gen.render_body(style="")`` — produces the cell HTML with
+   marimo's ``<marimo-island>`` web components.
+
+The head + body are concatenated and embedded in the staged ``.md``.
+``style=""`` suppresses marimo's default ``max-width: 740px`` wrapper
+so Material's content area controls width.
+
+Static reactivity (``precompute.enabled``) is automatically a no-op
+for WASM-rendered pages: the preprocessor's ``_run_precompute`` is
+called only for static-mode entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from marimo import MarimoIslandGenerator
+
+
+def render_wasm_page(py_path: Path, *, display_code: bool = False) -> str:
+    """Render a marimo notebook as a WASM-interactive page body.
+
+    Returns a single string suitable for splicing into the staged
+    ``.md`` page in place of the normal static cell rendering. The
+    string contains marimo's head assets (script + style tags) inline
+    at the top, followed by the cell HTML — modern browsers tolerate
+    ``<script>`` and ``<link>`` in body and execute them in document
+    order. Per-page head injection avoids polluting the global
+    ``extra_javascript`` list with marimo's bundle on non-WASM pages.
+
+    ``display_code`` toggles whether each cell's source is shown
+    alongside its output. The default is False (output only) since
+    marimo notebooks typically use ``hide_code=True`` setup cells.
+    """
+    gen = MarimoIslandGenerator.from_file(str(py_path), display_code=display_code)
+    asyncio.run(gen.build())
+    head = gen.render_head()
+    body = gen.render_body(style="")
+    return head + "\n" + body

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,13 +77,39 @@ def test_launch_buttons_defaults() -> None:
     assert b.launch_buttons.wasm is False  # v0.2
 
 
-def test_defaults_mode_static_only_in_v01() -> None:
-    # Only "static" is accepted in v0.1; v0.2 will add "wasm" and "hybrid".
+def test_defaults_mode_static_or_wasm() -> None:
+    """v0.2 added wasm; static stays the default."""
     b = Book.model_validate({"title": "T", "toc": [{"file": "a.md"}]})
     assert b.defaults.mode == "static"
 
+    b_wasm = Book.model_validate(
+        {"title": "T", "toc": [{"file": "a.md"}], "defaults": {"mode": "wasm"}}
+    )
+    assert b_wasm.defaults.mode == "wasm"
+
+    # ``hybrid`` is reserved on the roadmap but not yet a valid value.
     with pytest.raises(ValidationError):
-        Book.model_validate({"title": "T", "toc": [{"file": "a.md"}], "defaults": {"mode": "wasm"}})
+        Book.model_validate(
+            {"title": "T", "toc": [{"file": "a.md"}], "defaults": {"mode": "hybrid"}}
+        )
+
+
+def test_file_entry_per_page_mode_override() -> None:
+    """Per-entry ``mode`` overrides the book-wide default."""
+    b = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [
+                {"file": "a.py"},
+                {"file": "b.py", "mode": "wasm"},
+            ],
+        }
+    )
+    a, b_entry = b.toc[0], b.toc[1]
+    assert a.effective_mode("static") == "static"
+    assert b_entry.effective_mode("static") == "wasm"
+    # When the book default is wasm, an unset entry follows it.
+    assert a.effective_mode("wasm") == "wasm"
 
 
 def test_toc_entry_must_pick_one_shape() -> None:

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,0 +1,109 @@
+"""End-to-end test for the WASM (marimo islands) render path.
+
+The test runs the full Preprocessor.build() against a mode=wasm entry
+and asserts the staged page contains marimo's island markup. This
+exercises the marimo subprocess + asyncio path and takes a few seconds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from marimo_book.config import Book
+from marimo_book.preprocessor import Preprocessor
+
+
+def _wasm_book(book_dir: Path) -> Book:
+    """Tiny notebook with one slider, opted into WASM via the TOC entry."""
+    content = book_dir / "content"
+    content.mkdir()
+    (content / "demo.py").write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _():\n"
+        "    import marimo as mo\n"
+        "    return (mo,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    n = mo.ui.slider(1, 10, value=5)\n"
+        "    n\n"
+        "    return (n,)\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    return Book.model_validate(
+        {
+            "title": "Test",
+            "toc": [{"file": "content/demo.py", "mode": "wasm"}],
+        }
+    )
+
+
+def test_wasm_page_contains_island_markup(tmp_path: Path) -> None:
+    book = _wasm_book(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert not report.errors
+    assert report.pages == 1
+
+    staged = (out_dir / "docs" / "demo.md").read_text(encoding="utf-8")
+    # Marimo's CDN scripts injected at the top of the page body.
+    assert "@marimo-team/islands" in staged
+    # Each cell becomes a <marimo-island>.
+    assert "<marimo-island" in staged
+    # The slider becomes a marimo-slider web component (interactive).
+    assert "marimo-slider" in staged or "marimo-ui-element" in staged
+
+
+def test_wasm_page_skips_precompute(tmp_path: Path) -> None:
+    """Precompute is a no-op for WASM pages; marimo's runtime handles reactivity."""
+    book = _wasm_book(tmp_path)
+    # Enable precompute. WASM page should NOT trigger any precompute warnings.
+    payload = book.model_dump(mode="json")
+    payload["precompute"] = {"enabled": True}
+    book = Book.model_validate(payload)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 0
+    assert report.widgets_skipped == 0
+
+
+def test_static_page_unchanged_alongside_wasm_entry(tmp_path: Path) -> None:
+    """Adding a wasm entry to the TOC doesn't disturb static-mode entries."""
+    content = tmp_path / "content"
+    content.mkdir()
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    (content / "demo.py").write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell\n"
+        "def _():\n"
+        "    return\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/demo.py", "mode": "wasm"},
+            ],
+        }
+    )
+    out_dir = tmp_path / "_site_src"
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=out_dir)
+    assert not report.errors
+
+    intro = (out_dir / "docs" / "intro.md").read_text(encoding="utf-8")
+    assert "@marimo-team/islands" not in intro
+    assert "# Intro" in intro
+
+    demo = (out_dir / "docs" / "demo.md").read_text(encoding="utf-8")
+    assert "@marimo-team/islands" in demo


### PR DESCRIPTION
Per-entry \`mode: wasm\` in book.yml routes the page through marimo's \`MarimoIslandGenerator\` instead of our static cell-rendering pipeline. Marimo's runtime + Pyodide load in the browser at first paint; cells become natively reactive, continuous sliders work, no precompute caps apply.

**Recommended as per-page opt-in** for chapters that need full interactivity. Heavy first paint (~30 MB Pyodide download, cached after first visit) makes book-wide WASM impractical. Most pages should stay static.

## Implementation

- Widen \`FileEntry.mode\` and \`Defaults.mode\` to accept \`\"wasm\"\`. Per-entry override resolved against book-wide default via new \`FileEntry.effective_mode()\` helper.
- New \`transforms/wasm.py\`: \`render_wasm_page()\` invokes \`MarimoIslandGenerator.from_file()\`, awaits \`build()\`, returns \`render_head() + render_body(style=\"\")\` ready to splice into the staged page. Per-page head injection avoids polluting global \`extra_javascript\`.
- \`stage_page\` branches on effective mode: static path unchanged; WASM path calls \`render_wasm_page()\` and skips link rewrites.
- \`_run_precompute\` is gated on \`mode == \"static\"\` — WASM pages get reactivity from marimo's runtime, no need for our build-time pipeline.

## Styling (Phase 1)

- New CSS in \`extra.css\` overriding \`.marimo\` + \`marimo-island\` namespaces with our Geist fonts (replaces marimo's Lora/PT Sans).
- Suppresses per-island default margins, hides marimo's \"Initializing...\" spinner.
- KaTeX coexists with our MathJax (no console errors observed locally).
- Pixel-perfect match to our zinc/violet theme is a polish pass — Phase 2.

## Asset hosting

Default: marimo islands JS+CSS from jsdelivr CDN. Same CDN posture as our existing Google Fonts + MathJax loads. Pyodide loads from its own CDN inside marimo's bundle. Self-hosting on the roadmap for privacy-conscious / offline cases.

## Demo

\`docs/content/wasm_demo.py\` (in the docs site TOC under Authoring): a continuous \`mo.ui.slider(1, 100)\` driving live Python computation in the browser. Same widget call would render as static-only on a non-WASM page (no precompute candidate without an explicit step) — illustrates the difference cleanly.

## Test plan

- [x] 109/109 tests passing (3 new in \`tests/test_wasm.py\`, 1 reframed in \`tests/test_config.py\`)
- [x] Lint clean
- [x] Local docs build succeeds: \`marimo-book build -b docs/book.yml --rebuild\` produces a wasm_demo.md page with marimo island markup and CDN script tags
- [ ] Visual check after merge: the WASM demo page on the published docs should boot Pyodide and let the slider drive live recomputation

🤖 Generated with [Claude Code](https://claude.com/claude-code)