### PR TITLE
Date CHANGELOG for v0.1.0 (first stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] — 2026-04-26
+
+**First stable release.** marimo-book is suitable for real production
+use. The `book.yml` schema is frozen within the 0.1.x series — fields
+may be added (additive, backward-compatible) but no field will be
+removed or have its meaning changed without a major version bump.
+
+This release ships per-page WASM render mode via marimo's islands
+runtime, completing the render-mode story: every page can opt into
+its preferred reactivity model (static / static + precompute / WASM)
+based on the chapter's needs, with the rest staying fast and light.
 
 ### Added — WASM render mode (per-page opt-in)
 


### PR DESCRIPTION
Closes the alpha series. After merge, tag `v0.1.0` to publish marimo-book's first stable release.

The 6 alphas in the previous session shipped:

- v0.1.0a1: foundation
- v0.1.0a2: PyPI metadata + social cards
- v0.1.0a3: modern theme + autorefs + MyST removal
- v0.1.0a4: incremental build cache (31× dartbrains speedup)
- v0.1.0a5: static reactivity for single-widget pages
- v0.1.0a6: multi-widget reactivity + multi-line widget calls + dartbrains-driven fixes

Stable adds:

- WASM render mode via marimo islands (per-page opt-in)

The book.yml schema is frozen within 0.1.x — additive changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)