### PR TITLE
v0.1.1 — anywidget render fix, slider boot fix, drawdata demo, custom domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] — 2026-04-26
+
+Patch release: two render-path bug fixes plus a working drawdata
+anywidget demo on the docs site, and a top-level `CNAME` convention
+so the docs site can ship under a custom domain.
+
+### Fixed
+
+- **Anywidget render under `text/markdown` mime.** `marimo export
+  ipynb` sometimes downgrades an anywidget HTML bundle to a
+  `text/markdown` blob with the `<marimo-anywidget>` tag fully
+  HTML-escaped (`&lt;marimo-anywidget`). The mime-bundle picker now
+  detects that, unescapes, and routes through the existing rewriter
+  so the static mount `<div>` is emitted. Without this, anywidgets
+  authored via third-party libraries like
+  [drawdata](https://github.com/koaning/drawdata) would render as
+  visible escaped HTML text instead of the live widget.
+- **Precompute slider boot race.** Material's `document$` is an
+  RxJS `Subject` (not a `BehaviorSubject`) — subscribers added after
+  its initial emission miss it. Combined with the `defer`'d shim
+  script tag, direct page loads occasionally raced past the initial
+  `document$` event, leaving the precompute control mount empty (and
+  hidden by `:empty { display: none }` CSS, so invisible to authors).
+  Boot is now belt-and-suspenders: run once via `DOMContentLoaded` /
+  immediate, *and* subscribe to `document$` for instant-nav swaps.
+  All boot work is idempotent.
+
+### Added
+
+- **Top-level `CNAME` convention.** Drop a `CNAME` file at the book
+  root next to `book.yml`; the preprocessor copies it into the
+  staged docs tree so mkdocs ships it as `_site/CNAME`. GitHub Pages
+  preserves the custom-domain setting on every redeploy.
+- **drawdata anywidget demo** in the docs site
+  (`Authoring → Anywidget demo: drawdata`) — a live click-to-draw
+  scatter canvas that proves the static anywidget pipeline renders
+  third-party widgets correctly.
+
+### Changed
+
+- `marimobook.org` is the canonical docs URL (was
+  `ljchang.github.io/marimo-book/`).
+
 ## [0.1.0] — 2026-04-26
 
 **First stable release.** marimo-book is suitable for real production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] — 2026-04-26
+
+**First stable release.** marimo-book is suitable for real production
+use. The `book.yml` schema is frozen within the 0.1.x series — fields
+may be added (additive, backward-compatible) but no field will be
+removed or have its meaning changed without a major version bump.
+
+This release ships per-page WASM render mode via marimo's islands
+runtime, completing the render-mode story: every page can opt into
+its preferred reactivity model (static / static + precompute / WASM)
+based on the chapter's needs, with the rest staying fast and light.
 
 ### Added — WASM render mode (per-page opt-in)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,17 @@ install it (the docs job needs every extra the docs site uses).
 
 All seven are off by default in `marimo-book new` scaffolds.
 
+### Custom domain (CNAME)
+
+Drop a `CNAME` file at the book root (next to `book.yml`) containing
+the apex domain (e.g. `marimobook.org`). The preprocessor copies it
+into the staged docs tree so mkdocs ships it as `_site/CNAME` —
+GitHub Pages then keeps the custom-domain setting on every redeploy.
+DNS still has to be configured at the registrar (four `A` records on
+the apex pointing at GitHub's Pages IPs, plus a `www` `CNAME` →
+`<user>.github.io`). The `marimo-book` self-hosted docs use this
+pattern for `marimobook.org` (see `docs/CNAME`).
+
 ## Theme + CSS
 
 Default styling lives in `src/marimo_book/assets/extra.css` —

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/marimo-book.svg)](https://pypi.org/project/marimo-book/)
 [![CI](https://github.com/ljchang/marimo-book/actions/workflows/ci.yml/badge.svg)](https://github.com/ljchang/marimo-book/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-latest-blue)](https://ljchang.github.io/marimo-book/)
+[![Docs](https://img.shields.io/badge/docs-latest-blue)](https://marimobook.org/)
 
 Build clean, searchable static books from [marimo](https://marimo.io)
 notebooks and Markdown files.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+marimobook.org

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -13,7 +13,7 @@ copyright: "2026"
 license: MIT
 repo: https://github.com/ljchang/marimo-book
 branch: main
-url: https://ljchang.github.io/marimo-book/
+url: https://marimobook.org/
 
 theme:
   palette:
@@ -69,6 +69,7 @@ toc:
       - file: content/precompute_demo.py
       - file: content/wasm_demo.py
         mode: wasm
+      - file: content/anywidget_demo.py
       - file: content/dependencies.md
       - file: content/widgets.md
 

--- a/docs/content/anywidget_demo.py
+++ b/docs/content/anywidget_demo.py
@@ -1,0 +1,62 @@
+import marimo
+
+__generated_with = "0.23.3"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+    from drawdata import ScatterWidget
+
+    return ScatterWidget, mo
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Anywidget demo: drawdata
+
+    [drawdata](https://github.com/koaning/drawdata) is a small
+    [anywidget](https://anywidget.dev) — a self-contained ES module
+    that draws onto a `<canvas>`. **Click and drag** in the panel
+    below to scribble points; press a number key (`1`–`4`) before
+    drawing to switch the active class.
+
+    This page is **static** — there is no Python kernel running.
+    The widget renders because `marimo-book` extracts the inlined
+    ES module from `marimo export`'s output and mounts it via a
+    ~150-line shim (`marimo_book.js`). See [Anywidgets][] for the
+    full pipeline.
+    """)
+    return
+
+
+@app.cell
+def _(ScatterWidget, mo):
+    canvas = mo.ui.anywidget(ScatterWidget(height=320))
+    canvas
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## What you can and can't do statically
+
+    - ✅ The widget **renders** — anywidget's `_esm` trait is inlined
+      as a `data:` URL, so no kernel and no CDN are required.
+    - ✅ All **client-side interaction** works — drawing, brush
+      colours, the canvas itself.
+    - ❌ The drawn `data` cannot flow into a downstream Python cell.
+      That needs a kernel.
+
+    For genuine Python reactivity (drawn points → live DataFrame →
+    live plot) flip the chapter to `mode: wasm` in `book.yml`. See
+    the [WASM demo](wasm_demo.md) for what that looks like.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/content/example.py
+++ b/docs/content/example.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.2"
+__generated_with = "0.23.3"
 app = marimo.App()
 
 

--- a/src/marimo_book/assets/marimo_book.js
+++ b/src/marimo_book/assets/marimo_book.js
@@ -347,12 +347,21 @@
     initPrecomputeOnce(scope);
   }
 
-  if (typeof document$ !== "undefined" && document$.subscribe) {
-    // Material for MkDocs instant-navigation: re-init after each load.
-    document$.subscribe(() => bootAll(document));
-  } else if (document.readyState === "loading") {
+  // Boot chain: belt-and-suspenders so we run on direct page loads AND
+  // on Material's instant-navigation swaps. All boot work is idempotent
+  // (guarded by `:not([data-mb-precompute-init])` and `:not([data-mb-hydrated])`
+  // so multiple calls are safe). This matters because Material's
+  // `document$` is a Subject — subscribers added AFTER its initial
+  // emission miss the initial document. Our `defer` script can race
+  // that emission depending on script-tag ordering, so we always boot
+  // once via DOMContentLoaded / immediate, AND ALSO subscribe to
+  // document$ for instant-nav.
+  if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", () => bootAll(document));
   } else {
     bootAll(document);
+  }
+  if (typeof document$ !== "undefined" && document$.subscribe) {
+    document$.subscribe(() => bootAll(document));
   }
 })();

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -371,6 +371,13 @@ class Preprocessor:
             if dst.exists():
                 shutil.rmtree(dst)
             shutil.copytree(src, dst)
+        # Copy a top-level CNAME file (single line: the apex domain) if the
+        # author supplied one. mkdocs treats unknown files in docs_dir as
+        # static assets and ships them to site_dir, so GitHub Pages keeps
+        # the custom-domain setting on every redeploy.
+        cname_src = self.book_dir / "CNAME"
+        if cname_src.exists() and cname_src.is_file():
+            shutil.copy2(cname_src, docs_dir / "CNAME")
 
     def _run_precompute(
         self,

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -300,6 +300,16 @@ def _render_mime_bundle(
         )
     if "text/markdown" in data:
         md = _as_str(data["text/markdown"]).strip()
+        # `marimo export ipynb` sometimes downgrades an anywidget mime
+        # bundle to text/markdown with the <marimo-anywidget> tag fully
+        # HTML-escaped (`&lt;marimo-anywidget ...`). Detect that and
+        # route through the HTML path so the rewriter can mount it.
+        if md.startswith(("&lt;marimo-anywidget", "&lt;marimo-ui-element")):
+            return _render_html_output(
+                html.unescape(md),
+                cell_source=cell_source,
+                widget_defaults=widget_defaults,
+            )
         return md
     for mime in ("image/png", "image/jpeg"):
         if mime in data:

--- a/tests/fixtures/simple_notebook.py
+++ b/tests/fixtures/simple_notebook.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.2"
+__generated_with = "0.23.3"
 app = marimo.App(width="medium")
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,6 +8,7 @@ from marimo_book.config import Book
 from marimo_book.launch_buttons import render_button_row
 from marimo_book.transforms.callouts import render_callout_html
 from marimo_book.transforms.marimo_export import (
+    _render_mime_bundle,
     cells_to_markdown,
     export_notebook,
 )
@@ -94,3 +95,26 @@ def test_simple_notebook_renders_expected_sections() -> None:
     assert "admonition info marimo-book-callout" in md  # callout translated
     # The hidden import cell should not leak into the output.
     assert "import marimo as mo" not in md
+
+
+def test_anywidget_escaped_under_text_markdown_routes_to_html() -> None:
+    """Regression: marimo export sometimes downgrades anywidget HTML to a
+    text/markdown bundle with the <marimo-anywidget> tag fully escaped.
+    The mime-bundle picker must detect that, unescape, and run the
+    rewriter so the static mount div is emitted."""
+    bundle = {
+        "text/markdown": (
+            "&lt;marimo-anywidget data-initial-value=&#x27;{&amp;quot;model_id"
+            "&amp;quot;:&amp;quot;abc&amp;quot;}&#x27; "
+            "data-js-url=&#x27;&amp;quot;data:text/javascript;base64,QQ==&amp;quot;&#x27;"
+            "&gt;&lt;/marimo-anywidget&gt;"
+        ),
+    }
+    out = _render_mime_bundle(
+        bundle,
+        cell_source="canvas = mo.ui.anywidget(ScatterWidget(height=320))",
+    )
+    assert 'class="marimo-book-anywidget"' in out
+    assert "&lt;marimo-anywidget" not in out
+    # Literal kwarg from cell source seeds initial state.
+    assert '"height": 320' in out


### PR DESCRIPTION
## Summary

- **Bug fix:** anywidgets authored via third-party libraries (e.g. [drawdata](https://github.com/koaning/drawdata)) rendered as visible escaped HTML text instead of the live widget. `marimo export ipynb` sometimes downgrades the HTML bundle to `text/markdown` with the tag fully entity-escaped — the mime picker now detects that, unescapes, and routes through the existing rewriter.
- **Bug fix:** precompute slider control mounts could render empty on direct page loads. Material's `document$` is an RxJS `Subject` that doesn't replay, so a `defer`'d subscriber occasionally missed the initial emission. Boot is now belt-and-suspenders: `DOMContentLoaded` / immediate **and** `document$.subscribe`. All boot work is idempotent.
- **New:** a working drawdata anywidget demo on the docs site (`Authoring → Anywidget demo: drawdata`) — a click-to-draw scatter canvas that exercises the static anywidget pipeline end-to-end.
- **New:** top-level `CNAME` convention. Drop a `CNAME` file at the book root next to `book.yml`; the preprocessor copies it into the staged docs tree so mkdocs ships it as `_site/CNAME`. GitHub Pages then preserves the custom domain on every redeploy.
- **Docs URL:** `marimo-book.org` is now the canonical docs URL (was `ljchang.github.io/marimo-book/`).

## Test plan

- [x] `pytest -q` (110 passed, includes new regression test `test_anywidget_escaped_under_text_markdown_routes_to_html`)
- [x] `marimo-book build -b docs/book.yml` — drawdata canvas mount appears in built HTML; `_site/CNAME` contains `marimobook.org`
- [ ] CI green on this PR
- [ ] After merge: GitHub Pages Settings shows `marimobook.org` verified, HTTPS provisioned
- [ ] Browser smoke check on https://marimobook.org/anywidget_demo/ — canvas renders, click-and-drag draws

🤖 Generated with [Claude Code](https://claude.com/claude-code)