### PR TITLE
Install drawdata in docs CI for the anywidget demo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,8 @@ jobs:
         run: sudo apt-get update -y && sudo apt-get install -y libcairo2 libpango-1.0-0 libpangocairo-1.0-0
       - name: Install marimo-book + extras for docs build
         run: pip install -e '.[linkcheck,social,autorefs,pdf]'
+      - name: Install demo notebook deps (drawdata used by anywidget_demo.py)
+        run: pip install drawdata anywidget
       - name: Build docs
         run: marimo-book build -b docs/book.yml --strict
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

The v0.1.1 anywidget demo (`docs/content/anywidget_demo.py`) imports `drawdata.ScatterWidget`. CI doesn't install drawdata, so the deployed page currently shows a `ModuleNotFoundError` instead of the live canvas. Add a tiny install step alongside the existing docs extras.

## Test plan

- [ ] CI green
- [ ] After deploy, https://marimobook.org/anywidget_demo/ shows `<div class=\"marimo-book-anywidget\">` mount and a working canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)