### PR TITLE
Sweep orphan precompute temp dirs at build start

### DIFF
--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -34,7 +34,11 @@ from .config import Book, FileEntry, SectionEntry, UrlEntry
 from .launch_buttons import render_button_row
 from .shell import _nav_from_toc, emit_mkdocs_yml
 from .transforms.link_rewrites import apply_link_rewrites
-from .transforms.marimo_export import cells_to_markdown, export_notebook
+from .transforms.marimo_export import (
+    cells_to_markdown,
+    cleanup_orphan_precompute_dirs,
+    export_notebook,
+)
 from .transforms.precompute import (
     WidgetCandidate,
     estimate_renders_independent,
@@ -302,6 +306,13 @@ class Preprocessor:
         self._write_defaults(docs_dir)
 
         file_entries = _iter_file_entries(self.book.toc)
+
+        # Sweep orphan precompute temp dirs from previous interrupted runs
+        # (Ctrl-C, watcher restart, OOM). They live alongside the notebook
+        # so the precompute pipeline can resolve sibling-module imports;
+        # the trade-off is they leak when the marimo subprocess is killed.
+        for content_dir in {(self.book_dir / e.file).parent for e in file_entries}:
+            cleanup_orphan_precompute_dirs(content_dir)
         md_basenames = {_doc_relpath_for(e.file).with_suffix("").name for e in file_entries}
 
         cache = BuildCache(self.book_dir, self.book, force_rebuild=self.rebuild)

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -25,6 +25,7 @@ import base64
 import html
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -124,6 +125,25 @@ def export_notebook_with_overrides(
         tmp_in = Path(tmp_dir) / py_path.name
         tmp_in.write_text(rewritten_source, encoding="utf-8")
         return export_notebook(tmp_in, include_outputs=include_outputs, sandbox=sandbox)
+
+
+def cleanup_orphan_precompute_dirs(content_dir: Path) -> int:
+    """Remove leaked ``marimo_book_precompute_*`` dirs in ``content_dir``.
+
+    These are created by :func:`export_notebook_with_overrides` and removed
+    by its ``TemporaryDirectory`` context manager on normal exit. If the
+    process is interrupted mid-precompute (Ctrl-C, watcher restart, OOM)
+    the dir leaks and pollutes the source tree. Called from the
+    preprocessor before each build.
+    """
+    if not content_dir.is_dir():
+        return 0
+    removed = 0
+    for child in content_dir.iterdir():
+        if child.is_dir() and child.name.startswith("marimo_book_precompute_"):
+            shutil.rmtree(child, ignore_errors=True)
+            removed += 1
+    return removed
 
 
 def cells_to_markdown(


### PR DESCRIPTION
## Summary

The precompute pipeline creates a temp dir alongside each notebook (so marimo can resolve sibling-module imports identically). The \`TemporaryDirectory\` context manager removes the dir on normal exit, but if the marimo subprocess is interrupted — Ctrl-C, watcher restart, OOM kill — the dir leaks and pollutes the source tree (\`docs/content/marimo_book_precompute_*\`, \`content/marimo_book_precompute_*\` in user books).

This PR adds \`cleanup_orphan_precompute_dirs(content_dir)\` and calls it once per unique content directory at the start of every build. Existing leftovers get swept on the next build; future leaks self-clean. Verified locally: 17 leftover dirs gone after one build.

## Test plan

- [x] All 62 preprocessor + transforms + precompute tests pass
- [x] Local docs build leaves zero \`marimo_book_precompute_*\` dirs in \`docs/content/\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)