### PR TITLE
Plotly hydration + escaped marimo-element handling + inline precompute controls

### DIFF
--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -382,6 +382,15 @@
   height: auto;
 }
 
+/* Plotly mount. The marimo_book.js shim hydrates Plotly.js into this
+ * container; before hydration the div is empty (no flash of escaped
+ * data-figure JSON) thanks to the Material default code-block escaping. */
+.marimo-book-plotly {
+  width: 100%;
+  margin: 0.75rem 0;
+  min-height: 320px;  /* reserve space so layout doesn't jump on hydrate */
+}
+
 /* Marimo plain text / stream outputs rendered as <pre>. */
 pre.marimo-book-output-text {
   background: var(--md-code-bg-color, #f5f5f5);

--- a/src/marimo_book/assets/marimo_book.js
+++ b/src/marimo_book/assets/marimo_book.js
@@ -392,11 +392,58 @@
     }
   }
 
+  // Plotly hydration. Marimo emits `<marimo-plotly data-figure='{json}'>`
+  // for each figure; we rewrap it as `<div class="marimo-book-plotly">`
+  // server-side. This shim loads Plotly.js once on first encounter, then
+  // calls `Plotly.newPlot` per mount. Idempotent via [data-mb-plotly].
+  let _plotlyLoading = null;
+  function loadPlotly() {
+    if (window.Plotly) return Promise.resolve(window.Plotly);
+    if (_plotlyLoading) return _plotlyLoading;
+    _plotlyLoading = new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = "https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js";
+      s.crossOrigin = "anonymous";
+      s.onload = () => resolve(window.Plotly);
+      s.onerror = () => reject(new Error("Failed to load Plotly.js"));
+      document.head.appendChild(s);
+    });
+    return _plotlyLoading;
+  }
+
+  function hydratePlotly(scope) {
+    const mounts = scope.querySelectorAll(".marimo-book-plotly:not([data-mb-plotly])");
+    if (!mounts.length) return;
+    loadPlotly().then((Plotly) => {
+      mounts.forEach((mount) => {
+        if (mount.hasAttribute("data-mb-plotly")) return;
+        mount.setAttribute("data-mb-plotly", "");
+        let figure;
+        try {
+          figure = JSON.parse(mount.getAttribute("data-figure") || "{}");
+        } catch (e) {
+          console.warn("marimo-book: bad plotly data-figure", e);
+          return;
+        }
+        let config = {};
+        try {
+          config = JSON.parse(mount.getAttribute("data-config") || "{}");
+        } catch (e) {
+          // ignore — empty config is fine
+        }
+        const layout = figure.layout || {};
+        const responsive = { responsive: true, displaylogo: false, ...config };
+        Plotly.newPlot(mount, figure.data || [], layout, responsive);
+      });
+    }).catch((e) => console.warn("marimo-book: plotly hydration failed", e));
+  }
+
   function bootAll(root) {
     const scope = root || document;
     hydrateAll(scope);
     initPrecomputeOnce(scope);
     mountHeaderButtons(scope);
+    hydratePlotly(scope);
   }
 
   // Boot chain: belt-and-suspenders so we run on direct page loads AND

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -221,22 +221,42 @@ def _splice_precomputed_body(original_page: str, result) -> str:
     """Replace the staged page's body with the precomputed version.
 
     The original page is ``<launch buttons block>\\n\\n<body>``. We
-    preserve the launch-button row verbatim, inject the widget control
-    after it, and replace the body with ``result.body`` (which already
-    contains the cell wrappers + embedded lookup-table script blocks).
+    preserve the launch-button row verbatim and splice ``result.body``
+    (which already contains the cell wrappers + embedded lookup-table
+    script blocks) in place of the body.
 
-    If the page has no launch-button block (``repo`` not set in
-    ``book.yml``), we just prepend the widget control to the body.
+    The widget control row mounts inline, immediately above the first
+    reactive cell — putting the slider next to the content it controls
+    instead of stranded at the top of the page. If the body has no
+    reactive-cell marker (shouldn't happen for a precomputed page, but
+    defensive), we fall back to top-of-body placement.
     """
     marker_open = '<div class="marimo-book-buttons">'
     marker_close = "</div>"
+    body = _splice_controls_inline(result.body, result.widget_html)
     if marker_open in original_page:
         head_end = original_page.index(marker_open)
-        # Find the matching close — launch buttons render is one flat div.
         close_at = original_page.index(marker_close, head_end) + len(marker_close)
         head = original_page[:close_at]
-        return head + "\n\n" + result.widget_html + "\n\n" + result.body
-    return result.widget_html + "\n\n" + result.body
+        return head + "\n\n" + body
+    return body
+
+
+def _splice_controls_inline(body: str, widget_html: str) -> str:
+    """Insert the widget controls just before the first reactive cell.
+
+    The body is a Markdown blob with ``<div class="marimo-book-precompute-cell"
+    data-precompute-cell="N" …>`` markers around each cell whose output
+    depends on a widget. Placing controls there keeps the slider visually
+    adjacent to the brain plot / table / chart it drives.
+    """
+    if not widget_html:
+        return body
+    needle = '<div class="marimo-book-precompute-cell"'
+    pos = body.find(needle)
+    if pos == -1:
+        return widget_html + "\n\n" + body
+    return body[:pos] + widget_html + "\n\n" + body[pos:]
 
 
 def _file_sha256(path: Path) -> str:

--- a/src/marimo_book/transforms/anywidgets.py
+++ b/src/marimo_book/transforms/anywidgets.py
@@ -59,7 +59,11 @@ def rewrite_anywidget_html(
     3. Anything marimo itself inlined into ``data-initial-value`` (rare for
        static exports — usually just a ``model_id`` reference)
     """
-    if "marimo-anywidget" not in raw_html and "marimo-ui-element" not in raw_html:
+    if (
+        "marimo-anywidget" not in raw_html
+        and "marimo-ui-element" not in raw_html
+        and "marimo-plotly" not in raw_html
+    ):
         return raw_html
 
     soup = BeautifulSoup(raw_html, "lxml")
@@ -75,11 +79,16 @@ def rewrite_anywidget_html(
     for node in list(soup.find_all("marimo-anywidget")):
         _rewrap_anywidget(node, soup, seeded_state)
 
-    # Pass 2: unwrap or drop <marimo-ui-element> wrappers.
+    # Pass 2: rewrap <marimo-plotly data-figure='{json}'> → mount div.
+    # The marimo_book.js shim loads Plotly.js on first hit and renders.
+    for node in list(soup.find_all("marimo-plotly")):
+        _rewrap_plotly(node, soup)
+
+    # Pass 3: unwrap or drop <marimo-ui-element> wrappers.
     for wrapper in list(soup.find_all("marimo-ui-element")):
         _handle_ui_wrapper(wrapper)
 
-    # Pass 3: drop any remaining standalone control elements that slipped
+    # Pass 4: drop any remaining standalone control elements that slipped
     # past (e.g. <marimo-slider> appearing at top level outside a wrapper).
     for ctrl_name in _STANDALONE_CONTROLS:
         for node in list(soup.find_all(ctrl_name)):
@@ -128,6 +137,24 @@ def _rewrap_anywidget(
         div["data-initial-value"] = json.dumps(merged)
     for child in list(node.children):
         div.append(child.extract())
+    node.replace_with(div)
+
+
+def _rewrap_plotly(node: Tag, soup: BeautifulSoup) -> None:
+    """Convert ``<marimo-plotly data-figure='{json}'>`` into a static mount.
+
+    Marimo serialises a Plotly figure as a custom element with the entire
+    figure spec inlined as a JSON string on ``data-figure``. Our static
+    site has no marimo runtime, so we rewrap as
+    ``<div class="marimo-book-plotly" data-figure='{json}'>`` and let the
+    :file:`marimo_book.js` shim fetch Plotly.js from a CDN on first hit
+    and call ``Plotly.newPlot`` per mount.
+    """
+    div = soup.new_tag("div", attrs={"class": "marimo-book-plotly"})
+    for attr in ("data-figure", "data-config"):
+        val = node.get(attr)
+        if val is not None:
+            div[attr] = val
     node.replace_with(div)
 
 
@@ -237,7 +264,7 @@ def _handle_ui_wrapper(wrapper: Tag) -> None:
     """
     descendants = list(wrapper.find_all(True))
     has_mount = any(
-        d.name == "div" and "marimo-book-anywidget" in (d.get("class") or []) for d in descendants
+        d.name == "div" and (set(d.get("class") or []) & _MOUNT_CLASSES) for d in descendants
     )
     non_control_descendants = [d for d in descendants if d.name not in _STANDALONE_CONTROLS]
     if has_mount or non_control_descendants:
@@ -249,7 +276,12 @@ def _handle_ui_wrapper(wrapper: Tag) -> None:
 # --- module-level convenience -----------------------------------------------
 
 
-_ANYWIDGET_SENTINEL = re.compile(r"<marimo-(anywidget|ui-element)\b", re.IGNORECASE)
+# Mount-class names emitted by `_rewrap_anywidget` and `_rewrap_plotly`;
+# `_handle_ui_wrapper` checks for these to decide whether to unwrap or
+# decompose a `<marimo-ui-element>` parent.
+_MOUNT_CLASSES = frozenset({"marimo-book-anywidget", "marimo-book-plotly"})
+
+_ANYWIDGET_SENTINEL = re.compile(r"<marimo-(anywidget|ui-element|plotly)\b", re.IGNORECASE)
 
 
 def contains_anywidget(raw_html: str) -> bool:

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -324,7 +324,13 @@ def _render_mime_bundle(
         # bundle to text/markdown with the <marimo-anywidget> tag fully
         # HTML-escaped (`&lt;marimo-anywidget ...`). Detect that and
         # route through the HTML path so the rewriter can mount it.
-        if md.startswith(("&lt;marimo-anywidget", "&lt;marimo-ui-element")):
+        # Same trick for any marimo custom element that arrived escaped:
+        # <marimo-slider>, <marimo-switch>, etc. Without this, the raw
+        # tag leaks into the page as visible escaped text. The HTML path
+        # routes through `rewrite_anywidget_html` which strips standalone
+        # controls (they have no static analog and are typically replaced
+        # by precompute control mounts elsewhere on the page).
+        if md.startswith(_ESCAPED_MARIMO_PREFIXES):
             return _render_html_output(
                 html.unescape(md),
                 cell_source=cell_source,
@@ -396,6 +402,29 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 def _strip_ansi(s: str) -> str:
     return _ANSI_RE.sub("", s)
+
+
+# Marimo custom-element tags that may arrive HTML-escaped under a
+# text/markdown mime bundle. We treat any of them as "this is really
+# HTML, not markdown" and route through the rewriter (which strips
+# standalone controls and rewraps anywidgets). Mirrors
+# anywidgets._STANDALONE_CONTROLS plus the marimo-anywidget /
+# marimo-ui-element wrappers handled originally.
+_ESCAPED_MARIMO_PREFIXES: tuple[str, ...] = (
+    "&lt;marimo-anywidget",
+    "&lt;marimo-ui-element",
+    "&lt;marimo-plotly",
+    "&lt;marimo-slider",
+    "&lt;marimo-switch",
+    "&lt;marimo-dropdown",
+    "&lt;marimo-radio",
+    "&lt;marimo-number",
+    "&lt;marimo-text",
+    "&lt;marimo-button",
+    "&lt;marimo-checkbox",
+    "&lt;marimo-multiselect",
+    "&lt;marimo-form",
+)
 
 
 _BASE64_RE = re.compile(r"^[A-Za-z0-9+/=\s]+$")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -112,6 +112,18 @@ def test_simple_notebook_renders_expected_sections() -> None:
     assert "import marimo as mo" not in md
 
 
+def test_plotly_rewrap_emits_static_mount() -> None:
+    """`<marimo-plotly data-figure='{json}'>` rewraps to a div the JS
+    shim picks up to hydrate via Plotly.js."""
+    from marimo_book.transforms.anywidgets import rewrite_anywidget_html
+
+    raw = "<marimo-plotly data-figure='{&quot;data&quot;:[],&quot;layout&quot;:{}}' data-config='{}'></marimo-plotly>"
+    out = rewrite_anywidget_html(raw)
+    assert 'class="marimo-book-plotly"' in out
+    assert "marimo-plotly" not in out.replace("marimo-book-plotly", "")  # no original tag left
+    assert "data-figure=" in out
+
+
 def test_anywidget_escaped_under_text_markdown_routes_to_html() -> None:
     """Regression: marimo export sometimes downgrades anywidget HTML to a
     text/markdown bundle with the <marimo-anywidget> tag fully escaped.


### PR DESCRIPTION
## Summary

Three related rendering improvements that surfaced while polishing dartbrains' Thresholding and ICA chapters.

### 1. Plotly hydration

Marimo emits each plotly figure as a custom \`<marimo-plotly data-figure='{json}'>\` element with the full figure spec inlined. Material doesn't know what to do with the custom element, so charts rendered as either escaped text or empty divs. Now:

- **Server-side:** rewrap as \`<div class=\"marimo-book-plotly\" data-figure='{json}'>\` in \`anywidgets.rewrite_anywidget_html\`.
- **Client-side:** \`marimo_book.js\` lazy-loads Plotly.js from jsdelivr (2.35.2) on first encounter, then calls \`Plotly.newPlot\` per mount. Idempotent via \`[data-mb-plotly]\` guard.
- **CSS:** 320px reserved height on \`.marimo-book-plotly\` to prevent layout jump.

Verified on dartbrains/Thresholding_Group_Analyses: both Plotly figures hydrate with the full Plotly toolbar (zoom/pan/hover).

### 2. Escaped \`<marimo-*>\` handling

\`marimo export ipynb\` sometimes downgrades anywidget/plotly/ui-element bundles to a \`text/markdown\` mime with the angle brackets HTML-escaped (\`&lt;marimo-plotly\`, etc). Without handling, the raw escaped tag leaked as visible text on the page. The \`_render_mime_bundle\` path now detects the broader prefix list and routes through the unescape + rewriter path. The \`<marimo-plotly>\` tag was added to:
- \`_ANYWIDGET_SENTINEL\` regex
- \`_ESCAPED_MARIMO_PREFIXES\` tuple
- The standalone-controls list in \`_handle_ui_wrapper\`'s mount-class check

### 3. Inline precompute controls

The widget control mount used to splice at the top of the page body, often far from the cells it drove (e.g. ICA's brain-plot slider sat hundreds of px above the brain plot). Now \`_splice_controls_inline\` finds the first \`<div data-precompute-cell=\"N\">\` in the body and inserts the controls panel just above it. Falls back to top-of-body if no reactive marker is found (defensive, shouldn't happen).

## Test plan

- [x] \`pytest tests/\` (72 passing, +1 new \`test_plotly_rewrap_emits_static_mount\`)
- [x] \`ruff check\` + \`ruff format\` clean
- [x] dartbrains end-to-end: Plotly figures hydrate interactively, slider mounts adjacent to brain plot, no leaked \`<marimo-*>\` text anywhere
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)