### PR TITLE
Docs: cover v0.1.2 features + cleanup

### DIFF
--- a/docs/content/authoring.md
+++ b/docs/content/authoring.md
@@ -261,6 +261,35 @@ Every `.py` page gets an "Open in molab" launch button (configurable in
 `book.yml`) so readers can pop into a fully reactive marimo session for
 any chapter they want to modify.
 
+### Caching slow cells (`mo.persistent_cache`)
+
+For cells that take more than a few seconds to run (large simulations,
+ICA decompositions, big bootstraps), wrap the expensive computation in
+[`mo.persistent_cache`](https://docs.marimo.io/api/caching/) so the
+result lives on disk across builds. The first build pays the cost
+once; every subsequent build (including CI, if you commit the cache
+directory) is essentially instant.
+
+```python
+@app.cell
+def _(SimulateGrid, mo):
+    with mo.persistent_cache("fpr_sweep"):
+        simulation = SimulateGrid(grid_width=100, n_subjects=20)
+        simulation.run_multiple_simulations(threshold=0.05, n_simulations=100)
+    simulation.plot()  # cheap; runs every build
+    return
+```
+
+The cache lives at `__marimo__/cache/<cache_name>/` next to the
+notebook. Hash invalidation is automatic: edit any input variable in
+the cell and the cache for that key is rebuilt on the next run.
+
+If a cell is *so* slow that even the first build is impractical
+(massive parameter sweeps, multi-hour fits), fall back to
+`@app.cell(disabled=True)` — marimo skips the cell during static
+export but it stays runnable in `marimo edit`. Use this sparingly; the
+chapter will show no output for that cell.
+
 ## Live example
 
 [The next page](example.md) *is* a real marimo notebook, rendered by

--- a/docs/content/book_yml.md
+++ b/docs/content/book_yml.md
@@ -126,7 +126,8 @@ Each author supports `name` (required), `orcid`, `affiliation`, and
 |---|---|---|---|
 | `logo` | path | `None` | Relative to book root; copied into `images/` |
 | `favicon` | path | `None` | Relative to book root |
-| `theme.palette.primary` | hex color | Material default | Top bar + links |
+| `logo_placement` | `header` \| `sidebar` | `header` | `sidebar` puts a large logo above the left nav (Jupyter-Book chrome) |
+| `theme.palette.primary` | hex color | Material default | Top bar + links. Applied to *both* schemes (light + dark) |
 | `theme.palette.accent` | hex color | Material default | Highlights + active states |
 | `theme.font.text` | Google Font name | `Roboto` | Body font |
 | `theme.font.code` | Google Font name | `Roboto Mono` | Code font |
@@ -141,6 +142,10 @@ one that also applies to `.md` pages.
 - `download` — "Download .py" button (raw `.py` source).
 - `colab` / `binder` — reserved flags, no-op in v0.1.
 - `wasm` — reserved for v0.2.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `placement` | `header` \| `page` | `header` | `header` mounts icon-only buttons in Material's top bar; `page` keeps the legacy text-button row above each chapter title |
 
 ### Dependencies
 
@@ -176,9 +181,20 @@ clutter the rendered page. Set to `false` if you want the setup visible.
 Three shapes, inferred from which key is present:
 
 - `file: path` — a local `.md` or marimo `.py`, rendered as a page.
-  Optional `title:` overrides the first `#` heading in the file.
+  Optional `title:` overrides the first `#` heading in the file. Optional
+  `mode: wasm` opts that page into [WASM render mode][wasm].
 - `url: URL` (+ `title:`) — external link in the sidebar.
-- `section: name` + `children: [...]` — a nested group. Recursive.
+- `section: name` + `children: [...]` — a nested group. Recursive. An
+  empty section (`children:` blank or omitted) is silently dropped from
+  the nav, so you can stub out future groups without breaking the build.
+
+**The first `file:` entry becomes the home page.** Whatever it is —
+`content/intro.md`, `content/welcome.py`, anything — gets staged as
+`index.md` in the docs tree, so mkdocs serves it at `/`. This means the
+header logo's "back to home" link works without any extra configuration,
+and you don't need to know about the mkdocs `index.md` convention.
+
+[wasm]: building.md#wasm-render-mode
 
 ### Shell
 

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -298,10 +298,10 @@ small JS shim swaps the affected cells when the reader interacts with
 the widget.
 
 **This is the kernel-free reactivity path for `defaults.mode: static`
-(the only mode in v0.1.x).** When v0.2 introduces WASM render mode,
-WASM-rendered pages will get native reactivity via Pyodide and this
-whole pipeline will be a no-op for them — the static fallback works
-the same way either side of that transition.
+(the default).** WASM-rendered pages get native reactivity via Pyodide
+and this whole pipeline is a no-op for them — the static fallback
+works the same way either side of that line. See
+[WASM render mode](#wasm-render-mode) below.
 
 ### Opt in via `book.yml`
 
@@ -368,9 +368,12 @@ wrote it — there's nothing marimo-book-specific in the `.py`.
 - Single-slider plot explorations with ≤50 values
 
 **Bad fit:**
-- Continuous sliders that need fine-grained interactivity (use WASM
-  mode in v0.2 when it lands, or link to a molab session)
-- Notebooks where every cell is expensive (build time × N values)
+- Continuous sliders that need fine-grained interactivity (use
+  [WASM mode](#wasm-render-mode))
+- Notebooks where every cell is expensive (build time × N values).
+  Wrap the expensive cell in
+  [`mo.persistent_cache`](authoring.md#caching-slow-cells-mopersistent_cache)
+  so subsequent precompute runs hit the cache.
 - Multi-widget cross-products with shared downstream cells (v2)
 
 ### Build cost
@@ -381,6 +384,56 @@ wrote it — there's nothing marimo-book-specific in the `.py`.
   after the first export and aborts if projected runtime exceeds.
 - **The build cache** (v0.1.0a4) interacts with precompute correctly:
   toggling `precompute.enabled` invalidates affected pages.
+
+## WASM render mode
+
+For pages that need *full* Python reactivity — continuous sliders,
+arbitrary user input, real downstream re-execution — opt in per page:
+
+```yaml
+toc:
+  - file: content/intro.py            # static (default)
+  - file: content/explorer.py         # full WASM
+    mode: wasm
+```
+
+Or for a whole book:
+
+```yaml
+defaults:
+  mode: wasm
+```
+
+**What it does.** The preprocessor routes the page through marimo's
+[`MarimoIslandGenerator`](https://docs.marimo.io/api/exporting/#marimo.MarimoIslandGenerator).
+At first paint the browser downloads marimo's frontend bundle (~5 MB
+gzipped, jsdelivr CDN) plus Pyodide (~30 MB, lazy). Cells then become
+natively reactive — sliders work continuously, every cell re-runs on
+input change, no precompute caps apply.
+
+**When to use.** Per-page opt-in is the recommended pattern: leave most
+chapters static for instant first paint, flip `mode: wasm` only on
+the few that genuinely need full reactivity.
+
+**When NOT to use.** Compute-heavy notebooks fare badly under WASM —
+joblib's parallel backend doesn't run efficiently in Pyodide, and big
+NumPy/Pandas/scientific stacks have slow first-import in the browser.
+For one-shot expensive computations,
+[`mo.persistent_cache`](authoring.md#caching-slow-cells-mopersistent_cache)
+on a static page is faster end-to-end.
+
+**Caveats.**
+- First page load is heavy (~30 MB Pyodide download, cached after).
+- Not every Python package is in Pyodide's package set — check
+  [pyodide.org/packages](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
+- File system access via relative paths needs care: marimo's
+  `__file__` and `mo.notebook_dir()` resolve to internal paths under
+  `MarimoIslandGenerator`. If a notebook does
+  `Path(__file__).parent / "data"` it won't find the file. Use a
+  cwd-walk pattern instead, or wait for
+  [marimo-team/marimo#9391](https://github.com/marimo-team/marimo/issues/9391).
+
+The `Authoring → WASM demo` page in this book is a working example.
 
 ## ePub / other formats?
 

--- a/docs/content/deploying.md
+++ b/docs/content/deploying.md
@@ -35,9 +35,28 @@ Or if you're using `sandbox` mode, add a `uv` install step and pass
 
 ## Custom domain
 
-Put your domain in a `CNAME` file at the repo root. GitHub Pages picks
-it up automatically. Add a DNS CNAME record (or A records for an apex
-domain) pointing at `<your-username>.github.io`.
+Drop a `CNAME` file at your **book root** (next to `book.yml`) with a
+single line containing your apex domain — e.g.:
+
+```
+mybook.org
+```
+
+The preprocessor copies it into the staged docs tree on every build,
+so mkdocs ships it as `_site/CNAME`. GitHub Pages reads that file on
+each redeploy and keeps the custom-domain setting wired up.
+
+DNS at your registrar:
+
+- **Apex** (`mybook.org`) — four `A` records pointing at GitHub Pages:
+  `185.199.108.153`, `185.199.109.153`, `185.199.110.153`,
+  `185.199.111.153`.
+- **`www`** subdomain — one `CNAME` → `<your-username>.github.io`.
+
+Then in repo Settings → Pages, set Custom domain to `mybook.org`. Once
+GitHub provisions the Let's Encrypt cert (a few minutes after DNS
+verifies), tick "Enforce HTTPS". The marimo-book docs site uses this
+exact setup at [marimobook.org](https://marimobook.org/).
 
 ## Netlify
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -27,18 +27,29 @@ multi-chapter book from marimo notebooks. Your options were roughly:
   per-notebook experience; you can't stitch a set of chapters into a
   browsable book with a sidebar.
 - **WASM export** — `marimo export html-wasm` makes a notebook fully
-  interactive in a browser via Pyodide, but pyodide is still `wasm32`,
-  which caps memory at 2 GB and excludes many scientific-Python packages
-  like `nibabel`, `nilearn`, and `statsmodels`. Most non-trivial data
-  science books can't run in WASM.
+  interactive in a browser via Pyodide, but pyodide is `wasm32` (2 GB
+  memory cap) and missing many scientific-Python packages like
+  `nibabel`, `nilearn`, and `statsmodels`. Most non-trivial data
+  science books can't run end-to-end in WASM.
 
 `marimo-book` sits in the gap. It produces a **statically-rendered book**
 (every cell's output is baked at build time, so readers see real results
 without needing a Python kernel), with a per-chapter *"Open in molab"*
-button for readers who want to run and modify the code live. Anywidgets
-continue to work interactively on the static page via a small runtime
-shim, and heavy chapters that can't run in WASM render fine as static
-figures with a one-click escape hatch to molab.
+button for readers who want to run and modify the code live. Three
+reactivity tiers per page, author chooses:
+
+- **Static** (default) — server-rendered cell outputs. Instant first
+  paint, works offline, smallest bundle.
+- **Static + precompute** — discrete `mo.ui` widgets re-execute each
+  value at build time and ship a JSON lookup table; a JS shim swaps
+  the visible cells on input. Real-feeling interactivity, no kernel.
+- **WASM** (`mode: wasm` per page) — heavy chapters opt in to
+  marimo's island runtime; cells run natively in the browser via
+  Pyodide for full continuous reactivity.
+
+Anywidgets continue to work interactively on static pages via a small
+runtime shim. Plotly figures hydrate on first encounter via lazy CDN
+load.
 
 ## What it's not
 
@@ -54,15 +65,18 @@ figures with a one-click escape hatch to molab.
 
 ## Status
 
-Alpha (v0.1.0a1). Usable end-to-end — the tool is actively building a
-real course site ([dartbrains](https://github.com/ljchang/dartbrains))
-— but the `book.yml` schema may still change between minor versions
-before v1.0. Pin the exact version in your project until we signal
-stability.
+Stable, on PyPI as
+[`marimo-book`](https://pypi.org/project/marimo-book/). The current
+release is **v0.1.2** and the `book.yml` schema is **frozen within
+the 0.1.x series** — fields can be added (additive, backward-compatible)
+but no field will be removed or have its meaning changed without a
+major version bump.
 
-See the [roadmap](roadmap.md) for what's coming next, including WASM
-rendering, [zensical](https://zensical.org) migration, and citation
-support.
+Real-world usage: the tool is actively building a 30-chapter course site
+([dartbrains](https://github.com/ljchang/dartbrains)) plus this book
+itself. See the [roadmap](roadmap.md) for what's next, including
+subgraph re-execution for precompute and the
+[zensical](https://zensical.org) migration.
 
 ## Credits
 

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -21,47 +21,48 @@ not a contract.
 - `sandbox` dependency mode (PEP 723 per-notebook isolation via `uv`)
 - MIT license; PyPI Trusted Publishing workflow
 
+## Shipped since v0.1
+
+- **WASM render mode** (v0.1.0) — per-page `mode: wasm` opts a chapter
+  into marimo's `MarimoIslandGenerator`. Cells run natively in the
+  browser via Pyodide; sliders are continuously reactive. See
+  [Building → WASM render mode](building.md#wasm-render-mode).
+- **Static reactivity for discrete widgets** (v0.1.0a5) —
+  `precompute.enabled: true` re-exports each chapter once per widget
+  value at build time and ships the lookup table inline. Sliders work
+  on truly static pages, no browser kernel.
+- **Incremental build cache** (v0.1.0a4) — content-hashed cache cuts
+  warm rebuilds from ~107 s to ~3.4 s on dartbrains-sized books.
+- **Sidebar logo placement** (v0.1.2) — `logo_placement: sidebar`
+  renders a Jupyter-Book-style banner above the left nav.
+- **Header launch buttons + Plotly hydration** (v0.1.2) — molab /
+  GitHub / Download as icon buttons in Material's top bar; Plotly
+  figures are fully interactive on static pages.
+
 ## Next up (v0.2, in planning)
 
-### WASM / hybrid render modes
+### Subgraph re-execution for precompute
 
-Enable per-chapter interactivity without requiring a marimo kernel.
-Three modes, per-entry selection in `book.yml`:
-
-```yaml
-toc:
-  - file: content/MR_Physics.py
-    mode: wasm      # runs reactively in-browser via Pyodide
-  - file: content/GLM.py
-    mode: hybrid    # static by default, "Run interactively" button swaps in WASM
-  - file: content/Preprocessing.py
-    mode: static    # current behaviour
-```
-
-Pyodide remains `wasm32` (2 GB memory cap, no `nibabel`/`nilearn`
-support), so WASM works best for lightweight pedagogical chapters
-(physics simulations, small-data demos). Heavy fMRI chapters stay
-`static` with a molab escape hatch.
+Today's precompute (Path X) re-runs the full notebook per widget
+value. Path Y would drive marimo's `App.embed()` / `_ast` API directly
+to execute *only the downstream subgraph*, often 10-100× faster.
+Critical for chapters with expensive setup cells (large data loads,
+ICA decompositions) where wrapping in `mo.persistent_cache` only
+helps so much.
 
 ### Dependency-graph-aware build cache
 
 Marimo already computes a reactive DAG per notebook. Emit a build
 manifest so `marimo-book build` re-executes *only the cells whose
-upstream dependencies changed*, not the whole notebook. This is our
-single biggest authoring-UX lever — today's full rebuild of a 30-page
-book can take a minute; a smart cache would bring incremental edits to
-under 1 s.
+upstream dependencies changed*, not the whole notebook. Today's
+chapter-level cache invalidates on any source-file change; a
+cell-level cache would let one-line prose edits skip re-execution
+entirely.
 
 ### Citation hover-cards
 
 BibTeX ingest + `[@key]` rendering with Material's card syntax showing
 authors, title, year, DOI on hover. Modern-doc-site parity.
-
-### "Open in marimo WASM" launch button
-
-Replaces Jupyter Book's Thebe integration with marimo's native WASM
-bundle. Zero-install, in-page interactivity from any static chapter
-that fits within Pyodide's constraints.
 
 ## Medium term (v0.3+)
 

--- a/docs/content/widgets.md
+++ b/docs/content/widgets.md
@@ -86,6 +86,41 @@ in an animation loop."**
   re-runs the shim on every page load. For state that needs to
   persist, store it in `localStorage` from inside your widget's JS.
 
+## Plotly figures
+
+Plotly figures (anything that produces a `plotly.graph_objects.Figure`,
+including `make_subplots`, `px.scatter`, etc.) render fully interactive
+on static pages — zoom, pan, hover, the whole toolbar.
+
+The pipeline:
+
+1. Marimo's exporter emits each figure as
+   `<marimo-plotly data-figure='{json}' data-config='{json}'>` with the
+   complete figure spec inlined.
+2. The preprocessor rewraps it as
+   `<div class="marimo-book-plotly" data-figure='{json}'>`.
+3. On page load, `marimo_book.js` lazy-loads Plotly.js from jsdelivr
+   (cached after first chapter that has a chart) and calls
+   `Plotly.newPlot(mount, data, layout, config)` per mount.
+
+No kernel, no extra setup. Just write the figure as you would in any
+marimo notebook and it renders as the static last expression of its
+cell.
+
+```python
+@app.cell(hide_code=True)
+def _(go, x, y):
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=x, y=y, mode='lines'))
+    fig.update_layout(title="My chart", height=400)
+    fig
+    return
+```
+
+CSS reserves a 320 px slot before hydration so the page doesn't jump
+when Plotly mounts. If your chart needs more space, set
+`fig.update_layout(height=...)` — the Plotly height wins.
+
 ## Elements we strip
 
 Marimo's `<marimo-ui-element>` wrappers around standalone controls —
@@ -93,7 +128,10 @@ Marimo's `<marimo-ui-element>` wrappers around standalone controls —
 `<marimo-radio>`, `<marimo-number>`, `<marimo-button>` — require a
 running kernel to be meaningful. `marimo-book` strips them at preprocess
 time. For static pages, use an anywidget that includes its controls
-inside the widget itself.
+inside the widget itself, opt the page into
+[`mode: wasm`](building.md#wasm-render-mode), or rely on
+[`precompute.enabled`](building.md#static-reactivity) for
+discrete-value sliders.
 
 ## Example: dartbrains widgets
 


### PR DESCRIPTION
## Summary

Audit found that none of the v0.1.2 features were documented and the landing/roadmap pages still described WASM as planned-for-v0.2 (it actually shipped in v0.1.0). This PR catches the docs up.

| Page | Change |
|---|---|
| \`book_yml.md\` | Add \`logo_placement\`, \`launch_buttons.placement\`; cover empty-section tolerance + first-entry-becomes-index promotion |
| \`widgets.md\` | **New** "Plotly figures" section |
| \`authoring.md\` | **New** "Caching slow cells (\`mo.persistent_cache\`)" section |
| \`building.md\` | **New** "WASM render mode" section; fix stale "v0.2" refs + broken anchor |
| \`deploying.md\` | Rewrite custom-domain for the new CNAME-from-book-root convention; concrete DNS records |
| \`roadmap.md\` | Move WASM / precompute / build cache / sidebar logo / header buttons / plotly into "Shipped since v0.1"; reframe "next up" |
| \`index.md\` | Replace alpha messaging with v0.1.2 stable status; three-tier reactivity summary |

## Test plan

- [x] \`pytest\` (34 transforms/preprocessor/config tests passing)
- [x] \`marimo-book build -b docs/book.yml\` clean
- [ ] CI green
- [ ] Visual eyeball after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)