### PR TITLE
Render precompute lookup-table deltas to HTML at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Static reactivity demo: cell content rendered as raw markdown when
+  the slider was moved off its default value.** The precompute lookup
+  table embedded in each page stored marimo's markdown export of each
+  cell, but the JS shim sets `el.innerHTML = delta[idx]` directly —
+  pasting raw markdown into the DOM. The default-value cells looked
+  correct because they live in the page body and pass through mkdocs;
+  every other value's cells came out as ` ```python … ``` ` and
+  `| Scale | Value | |---|---| …`. The preprocessor now pre-renders
+  each delta to HTML at build time using the same Python-Markdown
+  extension list mkdocs is configured with, so the lookup-table values
+  match what mkdocs emits for the body. Latent since precompute first
+  shipped; only obvious after 0.1.2's inline-controls placement
+  (#19) put the slider next to the cells it drives.
+
 ## [0.1.2] — 2026-04-27
 
 Patch release: Jupyter-Book-style sidebar logo, header launch buttons

--- a/src/marimo_book/shell.py
+++ b/src/marimo_book/shell.py
@@ -81,7 +81,7 @@ def _build_config(
         *extra_javascript,
     ]
 
-    cfg["markdown_extensions"] = _markdown_extensions()
+    cfg["markdown_extensions"] = markdown_extensions()
 
     # Plugins: mkdocs's default is just `search`. Opt-in plugins require
     # matching ``marimo-book[...]`` extras; mkdocs fails fast with a clear
@@ -197,7 +197,15 @@ def _theme_block(book: Book) -> dict[str, Any]:
     return theme
 
 
-def _markdown_extensions() -> list:
+def markdown_extensions() -> list:
+    """Markdown-extension list mkdocs receives.
+
+    Public so other build-time stages (e.g. precompute lookup-table
+    rendering) can build a Python-Markdown instance with the same
+    extensions and produce HTML that matches what mkdocs emits for the
+    page body. Order matters — extensions stack onto Python-Markdown's
+    pipeline in this order.
+    """
     return [
         "abbr",
         "admonition",

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -46,6 +46,55 @@ from .marimo_export import (
     export_notebook_with_overrides,
 )
 
+
+def _split_extension_list(exts: list) -> tuple[list[str], dict[str, dict]]:
+    """Flatten mkdocs's mixed extension list into Python-Markdown's shape.
+
+    mkdocs accepts a list mixing bare strings and ``{name: {…cfg}}`` dicts;
+    Python-Markdown wants ``extensions=[names…]`` plus a separate
+    ``extension_configs={name: {…}}`` mapping.
+    """
+    names: list[str] = []
+    configs: dict[str, dict] = {}
+    for ext in exts:
+        if isinstance(ext, str):
+            names.append(ext)
+        elif isinstance(ext, dict):
+            for name, cfg in ext.items():
+                names.append(name)
+                if cfg:
+                    configs[name] = cfg
+    return names, configs
+
+
+def _make_md_renderer():
+    """Build a Python-Markdown instance using mkdocs's extension list.
+
+    Used to pre-render precompute-lookup-table delta values to HTML at
+    build time, so the JS shim's ``el.innerHTML = delta[idx]`` produces
+    correctly-styled cells (matching what mkdocs emits for the default
+    value's content in the page body).
+
+    Reuse across delta renders within a page; call ``.reset()`` between
+    ``convert()`` calls so stateful extensions (footnotes, toc) don't
+    accumulate.
+    """
+    import markdown as _md
+
+    from marimo_book.shell import markdown_extensions
+
+    names, configs = _split_extension_list(markdown_extensions())
+    return _md.Markdown(extensions=names, extension_configs=configs)
+
+
+def _render_segments_to_html(md_renderer, segments_dict: dict[int, str]) -> dict[int, str]:
+    out: dict[int, str] = {}
+    for idx, body in segments_dict.items():
+        md_renderer.reset()
+        out[idx] = md_renderer.convert(body)
+    return out
+
+
 # marimo widget call patterns we recognise. Keys are the dotted attribute
 # path; values name the discovery strategy used to extract value sets.
 _WIDGET_KIND_BY_ATTR: dict[str, str] = {
@@ -470,6 +519,13 @@ def precompute_page(
         )
 
     # Per widget: build deltas + downstream cell set.
+    #
+    # Each delta is rendered through Python-Markdown to HTML before being
+    # stored, so the lookup-table JSON the JS shim consumes via
+    # ``el.innerHTML = delta[idx]`` produces correctly-styled cells. The
+    # default-value cell content stays untouched — mkdocs renders it as
+    # part of the page body.
+    md_renderer = _make_md_renderer()
     per_widget: list[tuple[WidgetCandidate, dict[str, dict[int, str]], set[int]]] = []
     bytes_so_far = 0
     substitution_failures: list[str] = []  # collected for the result.skip_reason
@@ -499,9 +555,10 @@ def precompute_page(
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
                 continue
-            delta = {idx: html for idx, html in segments if base_by_idx.get(idx) != html}
-            if not delta:
+            delta_md = {idx: body for idx, body in segments if base_by_idx.get(idx) != body}
+            if not delta_md:
                 continue
+            delta = _render_segments_to_html(md_renderer, delta_md)
             deltas[_value_to_key(value)] = delta
             downstream.update(delta)
             bytes_so_far += sum(len(v) for v in delta.values())
@@ -606,9 +663,10 @@ def precompute_page(
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001
                 continue
-            delta = {idx: html for idx, html in segments if base_by_idx.get(idx) != html}
-            if not delta:
+            delta_md = {idx: body for idx, body in segments if base_by_idx.get(idx) != body}
+            if not delta_md:
                 continue
+            delta = _render_segments_to_html(md_renderer, delta_md)
             joint_table[_combo_key(combo)] = delta
             joint_downstream.update(delta)
             bytes_so_far += sum(len(v) for v in delta.values())

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -582,3 +582,106 @@ def test_preview_excluded_page_is_silent(tmp_path: Path) -> None:
     assert report.widgets_precomputed == 0
     assert report.widgets_skipped == 0
     assert not report.warnings
+
+
+def test_split_extension_list_separates_strings_and_dicts() -> None:
+    """The mkdocs-style mixed list flattens to Python-Markdown's two-arg shape."""
+    from marimo_book.transforms.precompute import _split_extension_list
+
+    names, configs = _split_extension_list(
+        [
+            "tables",
+            "md_in_html",
+            {"toc": {"permalink": True}},
+            {"pymdownx.highlight": {"line_spans": "__span"}},
+            {"pymdownx.betterem": {}},  # empty config dict — name kept, no config entry
+        ]
+    )
+    assert names == [
+        "tables",
+        "md_in_html",
+        "toc",
+        "pymdownx.highlight",
+        "pymdownx.betterem",
+    ]
+    assert configs == {
+        "toc": {"permalink": True},
+        "pymdownx.highlight": {"line_spans": "__span"},
+    }
+
+
+def test_precompute_lookup_table_values_are_rendered_html(tmp_path: Path) -> None:
+    """Per-value lookup-table cells must contain HTML, not raw markdown.
+
+    Regression test: the JS shim does ``el.innerHTML = delta[idx]``, so if
+    the table stored markdown source the page would show ``\\`\\`\\`python
+    …\\`\\`\\``` and ``| Scale | Value |`` literally when the user dragged
+    the slider off its default value. We render each delta to HTML at build
+    time using mkdocs's extension list so the swap produces correctly-styled
+    cells that match the default-value cells mkdocs renders into the body.
+    """
+    import json
+    import re
+
+    content = tmp_path / "content"
+    content.mkdir()
+    nb = content / "demo.py"
+    # Cell 2 emits a fenced code block + a markdown table — both pieces
+    # whose markdown→HTML rendering is structurally distinct from the
+    # markdown source (no false positives via substring overlap).
+    nb.write_text(
+        "import marimo\n\n"
+        "__generated_with = '0.23.3'\n"
+        "app = marimo.App()\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _():\n"
+        "    import marimo as mo\n"
+        "    return (mo,)\n\n"
+        "@app.cell\n"
+        "def _(mo):\n"
+        "    n = mo.ui.slider(steps=[1, 2, 3])\n"
+        "    return (n,)\n\n"
+        "@app.cell(hide_code=True)\n"
+        "def _(mo, n):\n"
+        "    mo.md(f'| Scale | Value |\\n|---|---|\\n| n | **{n.value}** |')\n"
+        "    return\n\n"
+        'if __name__ == "__main__":\n'
+        "    app.run()\n",
+        encoding="utf-8",
+    )
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "precompute": {"enabled": True},
+            "toc": [{"file": "content/demo.py"}],
+        }
+    )
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.widgets_precomputed == 1, report.warnings
+
+    staged = (tmp_path / "_site_src" / "docs" / "index.md").read_text(encoding="utf-8")
+    match = re.search(
+        r'<script type="application/json" class="marimo-book-precompute-table"[^>]*>'
+        r"(.*?)</script>",
+        staged,
+        re.DOTALL,
+    )
+    assert match is not None, "lookup-table script not emitted"
+    table = json.loads(match.group(1))
+    # Values 2 and 3 are non-default; both should be HTML.
+    assert {"2", "3"}.issubset(table.keys()), table.keys()
+    for value_key, delta in table.items():
+        joined = "\n".join(delta.values())
+        # The slider cell (a fenced code block) renders via pymdownx.highlight.
+        assert 'class="language-python highlight"' in joined, (
+            f"value {value_key}: code block cell didn't render to highlight HTML, got: {joined!r}"
+        )
+        # The downstream cell (a markdown table) renders via the tables ext.
+        assert "<table>" in joined, (
+            f"value {value_key}: table cell didn't render to <table>, got: {joined!r}"
+        )
+        # Raw markdown table syntax must not survive into the lookup table.
+        assert "|---|" not in joined, (
+            f"value {value_key} still contains raw markdown table delimiters"
+        )


### PR DESCRIPTION
## Summary

- The JSON lookup table embedded on each precomputed page stored marimo's *markdown* export of every cell, but `marimo_book.js` does `el.innerHTML = delta[idx]` to swap cells when the user moves a widget — pasting raw markdown source into the DOM. The default-value cells looked correct only because they live in the page body and pass through mkdocs; every other value's cells came out as ` \`\`\`python … \`\`\` ` and `| Scale | Value | |---|---| …`.
- Fix: pre-render each delta to HTML in `precompute_page()` using a Python-Markdown instance configured with the same extension list mkdocs is given (`shell.markdown_extensions()`, promoted to public). Applied at both delta-collection sites — independent path and joint cross-product. The default-body path is unchanged.
- Latent since precompute first shipped; only became visually obvious after 0.1.2's #19 placed the slider inline next to the cells it drives.

## Test plan

- [x] `pytest -q` — 119/119 pass (added `test_precompute_lookup_table_values_are_rendered_html` regression that builds a tiny precompute page and asserts every delta value contains `<table>` and `class="language-python highlight"` and no `\`\`\`python` / `|---|` markdown markers survive)
- [x] `pytest -q` — also added `test_split_extension_list_separates_strings_and_dicts` (pure-data test on the mkdocs→Python-Markdown extension-list flattening)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `marimo-book build -b docs/book.yml --rebuild` — succeeds (cairosvg warnings unrelated; pre-existing local libcairo absence)
- [x] Manually inspected `docs/_site/precompute_demo/index.html` — `temperature_c` lookup table now contains rendered HTML for every non-default value (`<table><thead>…<strong>25 °C</strong>…<em>warm</em>…</table>` for cell 3, `<div class="language-python highlight"><pre>…</pre></div>` for cell 2)

## Files

- `src/marimo_book/shell.py` — promote `_markdown_extensions()` → `markdown_extensions()` so other build stages can mirror mkdocs's exact extension list
- `src/marimo_book/transforms/precompute.py` — add `_split_extension_list`, `_make_md_renderer`, `_render_segments_to_html` helpers; wire them into both delta-collection sites
- `tests/test_precompute.py` — two new tests covering the rendered-HTML invariant and the extension-list flattening
- `CHANGELOG.md` — `[Unreleased]` Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)