### PR TITLE
Date CHANGELOG for v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] — 2026-04-27
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- One-line CHANGELOG dating: `[Unreleased]` → `[0.1.3] — 2026-04-27` so the precompute-deltas-render-to-HTML fix (#22) ships under the 0.1.3 tag, per the release flow in `CLAUDE.md`.

## Test plan

- [x] No code changes — only the CHANGELOG heading line is touched.
- [ ] After merge: publish the release-drafter draft on GitHub with tag `v0.1.3`. The `v*` tag fires `publish.yml` → hatch-vcs builds wheel `0.1.3` → PyPI via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)