### PR TITLE
Style cell-output tables, add suppress_warnings flag, doc cap tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`defaults.suppress_warnings`** flag in `book.yml`. When `true`, the
+  preprocessor runs `marimo export` with `PYTHONWARNINGS=ignore` so
+  third-party library warnings (numpy, pandas, deprecation notices,
+  etc.) don't surface as visible stderr blocks in cell output. Off by
+  default so existing books don't lose visible warnings unexpectedly.
+  Useful for tutorial books that import scientific libraries whose
+  routine warnings distract from the lesson.
+- **Tuning-caps section** in `Building → Static reactivity` docs.
+  Documents how to interpret the build report's `widgets_skipped`
+  warning and which `precompute.max_*` cap to bump for common
+  patterns (heavy imports, large per-render HTML, joint groups).
+
+### Fixed
+
+- **DataFrame tables rendered with browser-default styling.** The
+  prose-table CSS rule was scoped to `table:not([class])`, which
+  silently missed pandas tables (they ship with `class="dataframe"`)
+  and any marimo cell-output table. Tables under
+  `.marimo-book-output` and `table.dataframe` now get the same
+  hairline border + zebra striping + padding treatment as prose
+  tables, plus a subtle treatment for the empty index-column header
+  pandas emits.
+
 ## [0.1.3] — 2026-04-27
 
 ### Fixed

--- a/docs/content/book_yml.md
+++ b/docs/content/book_yml.md
@@ -75,6 +75,7 @@ defaults:
   hide_author_line: true
   show_source_link: true
   hide_first_code_cell: true
+  suppress_warnings: false   # set true to hide library warnings in cell output
 
 # Table of contents (nested; sections, files, external URLs)
 toc:
@@ -171,10 +172,23 @@ Opt-in Plausible or Google Analytics. Injected via Material for MkDocs'
 
 ### Defaults
 
-Page-level rendering defaults. The most useful one today:
-`hide_first_code_cell: true` hides the first code cell of every marimo
-notebook (almost always `import marimo as mo` setup) so it doesn't
-clutter the rendered page. Set to `false` if you want the setup visible.
+Page-level rendering defaults.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `mode` | `static` \| `wasm` | `static` | Render mode for `.py` notebooks |
+| `hide_author_line` | bool | `true` | Hide the author byline rendered into each chapter |
+| `show_source_link` | bool | `true` | Show the source-link icon next to the title |
+| `hide_first_code_cell` | bool | `true` | Drop the conventional `import marimo as mo` setup cell |
+| `suppress_warnings` | bool | `false` | Run notebook export with `PYTHONWARNINGS=ignore` so library warnings don't surface as visible stderr blocks in the page |
+
+`suppress_warnings: true` is useful for tutorial books that import
+scientific libraries — numpy, pandas, scikit-learn, etc. routinely
+emit deprecation and conversion warnings that distract from the
+lesson. The flag suppresses warnings at the kernel level (not in
+post-processing), so they're never captured as cell stderr.
+Genuine errors still surface; only `warnings.warn(...)` output is
+silenced.
 
 ### TOC entries
 

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -385,6 +385,40 @@ wrote it — there's nothing marimo-book-specific in the `.py`.
 - **The build cache** (v0.1.0a4) interacts with precompute correctly:
   toggling `precompute.enabled` invalidates affected pages.
 
+### Tuning caps for heavy notebooks
+
+When a precompute opt-in page renders static instead of interactive
+(e.g. the slider control is missing from the published page), the
+build report's `warnings:` section will name the cap that tripped:
+
+```text
+content/ICA.py: projected runtime (72.0s × 10 renders) exceeds
+  max_seconds_per_page (60s); rendered static.
+```
+
+Common patterns and the cap to bump:
+
+| Symptom | Cap to raise |
+|---|---|
+| Notebook with expensive imports (nilearn, scikit-learn warm-up) | `max_seconds_per_page` |
+| Each render emits a large HTML blob (whole-brain plot, big DataFrame) | `max_bytes_per_page` |
+| Many widgets joint-grouped (cross-product blows up) | `max_combinations_per_page` |
+| Single widget has more than 50 values | `max_values_per_widget` |
+
+Concrete example for a neuroimaging tutorial whose ICA chapter
+takes ~7s per render and ships ~1 MB of brain HTML per value:
+
+```yaml
+precompute:
+  enabled: true
+  max_seconds_per_page: 600    # 10 minutes, room for 80 renders × 7s
+  max_bytes_per_page: 50000000 # 50 MB, room for ~25 brain images
+```
+
+Caps apply per-page, so bumping them globally only costs build
+time on pages that actually exceed the defaults — fast pages keep
+their fast budget.
+
 ## WASM render mode
 
 For pages that need *full* Python reactivity — continuous sliders,

--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -263,6 +263,57 @@
   border-bottom: 1px solid var(--md-default-fg-color--lightest);
 }
 
+/* Pandas/marimo cell output tables. The :not([class]) rule above misses
+ * these because pandas attaches class="dataframe", and marimo-book wraps
+ * cell outputs in <div class="marimo-book-output">. Mirror the prose-table
+ * styling so DataFrames look at home in the book. */
+.md-typeset .marimo-book-output table,
+.md-typeset table.dataframe {
+  border-collapse: collapse;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px;
+  overflow: hidden;
+  font-size: 0.78rem;
+  margin: 0.5rem 0;
+}
+.md-typeset .marimo-book-output th,
+.md-typeset table.dataframe th {
+  background: var(--md-default-bg-color--light);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.4rem 0.7rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  border-right: 0;
+}
+.md-typeset .marimo-book-output td,
+.md-typeset table.dataframe td {
+  padding: 0.35rem 0.7rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+  border-right: 0;
+}
+.md-typeset .marimo-book-output tr:nth-child(even) td,
+.md-typeset table.dataframe tbody tr:nth-child(even) td {
+  background: var(--md-default-bg-color--light);
+}
+/* Pandas emits an empty <th></th> for the index column header; keep it
+ * subtle rather than forcing it bold-and-bordered. */
+.md-typeset .marimo-book-output th:empty,
+.md-typeset table.dataframe th:empty {
+  background: transparent;
+  border-bottom-color: transparent;
+}
+/* Numeric index column reads better right-aligned. Pandas writes it as
+ * <th> in <tbody>, so target both possibilities. */
+.md-typeset .marimo-book-output tbody th,
+.md-typeset table.dataframe tbody th {
+  background: transparent;
+  font-weight: 500;
+  color: var(--md-default-fg-color--light);
+  text-align: right;
+  padding: 0.35rem 0.7rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
 /* --- marimo-book-specific elements (preserved) --------------------------- */
 
 /* Launch buttons. Two layouts:

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -180,6 +180,11 @@ class Defaults(BaseModel):
     # ``hide_code=True``), but it's almost never part of the lesson. Drop it
     # unconditionally by default; authors can opt out per-book.
     hide_first_code_cell: bool = True
+    # When True, run ``marimo export`` with ``PYTHONWARNINGS=ignore`` so
+    # third-party library warnings (numpy, pandas, deprecation notices, etc.)
+    # don't surface as visible stderr blocks in the rendered page. Off by
+    # default so existing books don't lose visible warnings unexpectedly.
+    suppress_warnings: bool = False
 
 
 # --- TOC entries (discriminated union) ---------------------------------------

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -488,6 +488,7 @@ class Preprocessor:
             max_bytes=cfg.max_bytes_per_page,
             max_combinations=cfg.max_combinations_per_page,
             sandbox=self.sandbox,
+            suppress_warnings=self.book.defaults.suppress_warnings,
         )
         if result.skipped:
             report.warnings.append(f"{entry.file}: {result.skip_reason}")
@@ -625,7 +626,11 @@ def stage_page(
 
 
 def _render_marimo(src: Path, book: Book, *, sandbox: bool = False) -> str:
-    exp = export_notebook(src, sandbox=sandbox)
+    exp = export_notebook(
+        src,
+        sandbox=sandbox,
+        suppress_warnings=book.defaults.suppress_warnings,
+    )
     return cells_to_markdown(
         exp,
         hide_first_code_cell=book.defaults.hide_first_code_cell,

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import base64
 import html
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -54,12 +55,17 @@ def export_notebook(
     *,
     include_outputs: bool = True,
     sandbox: bool = False,
+    suppress_warnings: bool = False,
 ) -> ExportedNotebook:
     """Run ``marimo export ipynb`` and return the parsed notebook JSON.
 
     ``sandbox=True`` passes ``--sandbox`` to marimo, which reads the
     notebook's PEP 723 inline metadata and runs the export in an isolated
     ``uv run --isolated`` environment. Requires ``uv`` on PATH.
+
+    ``suppress_warnings=True`` sets ``PYTHONWARNINGS=ignore`` in the export
+    subprocess's environment so library warnings don't bleed into cell
+    stderr (and from there into the rendered page).
     """
     py_path = Path(py_path)
     cmd = [
@@ -76,6 +82,8 @@ def export_notebook(
     if sandbox:
         cmd.append("--sandbox")
 
+    env = {**os.environ, "PYTHONWARNINGS": "ignore"} if suppress_warnings else None
+
     # Route the temp .ipynb through a system temp dir so `marimo-book serve`'s
     # watcher can never see creates/deletes happening in the source tree.
     # Marimo uses the ``.py``'s own path as the working directory for cell
@@ -84,7 +92,7 @@ def export_notebook(
     with tempfile.TemporaryDirectory(prefix="marimo_book_") as tmp_dir:
         tmp_out = Path(tmp_dir) / f"{py_path.stem}.ipynb"
         cmd.extend(["-o", str(tmp_out)])
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
         # marimo exits non-zero when *some* cells fail to execute but still
         # produces a valid ipynb with error outputs. We accept that case
         # because the preprocessor then emits the error cell visibly.
@@ -106,6 +114,7 @@ def export_notebook_with_overrides(
     rewritten_source: str,
     include_outputs: bool = True,
     sandbox: bool = False,
+    suppress_warnings: bool = False,
 ) -> ExportedNotebook:
     """Run ``marimo export`` against ``rewritten_source`` instead of the file.
 
@@ -124,7 +133,12 @@ def export_notebook_with_overrides(
     ) as tmp_dir:
         tmp_in = Path(tmp_dir) / py_path.name
         tmp_in.write_text(rewritten_source, encoding="utf-8")
-        return export_notebook(tmp_in, include_outputs=include_outputs, sandbox=sandbox)
+        return export_notebook(
+            tmp_in,
+            include_outputs=include_outputs,
+            sandbox=sandbox,
+            suppress_warnings=suppress_warnings,
+        )
 
 
 def cleanup_orphan_precompute_dirs(content_dir: Path) -> int:

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -467,6 +467,7 @@ def precompute_page(
     max_bytes: int,
     max_combinations: int,
     sandbox: bool = False,
+    suppress_warnings: bool = False,
 ) -> PrecomputeResult:
     """Re-export a notebook once per (widget, value), return the staged body.
 
@@ -496,7 +497,7 @@ def precompute_page(
     t0 = time.monotonic()
     source = py_path.read_text(encoding="utf-8")
 
-    base_export = export_notebook(py_path, sandbox=sandbox)
+    base_export = export_notebook(py_path, sandbox=sandbox, suppress_warnings=suppress_warnings)
     base_segments = cells_to_markdown_segments(base_export)
     base_seconds = time.monotonic() - t0
     base_by_idx = {idx: html for idx, html in base_segments}
@@ -550,7 +551,10 @@ def precompute_page(
                 continue
             try:
                 export = export_notebook_with_overrides(
-                    py_path, rewritten_source=rewritten, sandbox=sandbox
+                    py_path,
+                    rewritten_source=rewritten,
+                    sandbox=sandbox,
+                    suppress_warnings=suppress_warnings,
                 )
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
@@ -658,7 +662,10 @@ def precompute_page(
                 continue
             try:
                 export = export_notebook_with_overrides(
-                    py_path, rewritten_source=rewritten, sandbox=sandbox
+                    py_path,
+                    rewritten_source=rewritten,
+                    sandbox=sandbox,
+                    suppress_warnings=suppress_warnings,
                 )
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,3 +115,18 @@ def test_file_entry_per_page_mode_override() -> None:
 def test_toc_entry_must_pick_one_shape() -> None:
     with pytest.raises(ValidationError):
         Book.model_validate({"title": "T", "toc": [{"unknown_kind": "oops"}]})
+
+
+def test_defaults_suppress_warnings_round_trip() -> None:
+    """``defaults.suppress_warnings`` is False by default and accepts True."""
+    b = Book.model_validate({"title": "T", "toc": [{"file": "a.md"}]})
+    assert b.defaults.suppress_warnings is False
+
+    b_on = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [{"file": "a.md"}],
+            "defaults": {"suppress_warnings": True},
+        }
+    )
+    assert b_on.defaults.suppress_warnings is True

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -89,3 +89,31 @@ def test_export_notebook_passes_sandbox_flag(tmp_path: Path) -> None:
 
         marimo_export.export_notebook(fake_py, sandbox=False)
         assert "--sandbox" not in captured[-1]
+
+
+def test_export_notebook_threads_suppress_warnings_env(tmp_path: Path) -> None:
+    """``suppress_warnings=True`` sets PYTHONWARNINGS=ignore on the subprocess env."""
+    fake_py = tmp_path / "nb.py"
+    fake_py.write_text("import marimo\napp = marimo.App()\n")
+
+    class _FakeResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    captured_envs: list[dict | None] = []
+
+    def fake_run(cmd, **kw):
+        captured_envs.append(kw.get("env"))
+        out_path = Path(cmd[cmd.index("-o") + 1])
+        out_path.write_text('{"cells": [], "metadata": {}}')
+        return _FakeResult()
+
+    with patch.object(marimo_export.subprocess, "run", side_effect=fake_run):
+        marimo_export.export_notebook(fake_py, suppress_warnings=True)
+        assert captured_envs[-1] is not None
+        assert captured_envs[-1].get("PYTHONWARNINGS") == "ignore"
+
+        marimo_export.export_notebook(fake_py, suppress_warnings=False)
+        # Default — let subprocess inherit the parent environment unchanged.
+        assert captured_envs[-1] is None


### PR DESCRIPTION
## Summary
- **Tables**: DataFrame and other cell-output tables now match the prose-table aesthetic (hairline border, zebra striping, padding). The existing rule was scoped to `table:not([class])` which silently missed pandas tables (`class=\"dataframe\"`) — they were rendering with browser defaults.
- **`defaults.suppress_warnings`** flag: opt-in book-wide setting that runs `marimo export` with `PYTHONWARNINGS=ignore` so library warnings don't surface as visible stderr blocks in cell output. Off by default; tutorial books importing scientific libraries can opt in.
- **Cap-tuning docs**: explain how to interpret the build report's `widgets_skipped` warning and which `precompute.max_*` cap to bump for common patterns. Reproduces the dartbrains ICA chapter's case where the slider silently disappeared at default caps.

Driven by polishing the freshly-deployed dartbrains marimo-book port (`dartbrains.org`).

## Test plan

- [x] `pytest -q` — 121 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `marimo-book build -b docs/book.yml` — site builds (cairo warnings are env-level missing-libcairo, unrelated)
- [x] New `test_defaults_suppress_warnings_round_trip` — schema round-trip
- [x] New `test_export_notebook_threads_suppress_warnings_env` — confirms `PYTHONWARNINGS=ignore` lands on the export subprocess env

🤖 Generated with [Claude Code](https://claude.com/claude-code)