### PR TITLE
Fix anywidgets rendering empty on WASM-mode pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - **Precompute slider mounted inline with the wrong cell when an
   upstream cell emitted non-deterministic stderr.** The downstream-
   detection diff in `precompute_page` compared cell bodies byte-for-
@@ -23,6 +24,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as downstream. Stored cell bodies still keep their stderr — only
   the comparison key is normalized. Surfaced by the dartbrains ICA
   chapter.
+=======
+- **Anywidgets rendered empty on WASM-mode pages.** marimo's
+  `MarimoIslandGenerator` runs under `ScriptRuntimeContext` which
+  hardcodes `virtual_files_supported=False`, so every anywidget's
+  ES module is emitted as a `data:text/javascript;base64,...` URL.
+  marimo's islands runtime then refuses to load these
+  ("Refusing to load anywidget module from untrusted URL") because
+  its trust check only accepts `@file/...` URLs. Result: every
+  anywidget on a WASM page disappeared from the DOM — completely
+  broken for books like dartbrains' MR_Physics chapter that ship
+  custom physics-simulation widgets. The WASM render path now
+  post-processes the islands body with the same anywidget rewrite
+  as static mode (with `keep_marimo_controls=True` so live
+  `<marimo-slider>` / `<marimo-dropdown>` / etc. continue to work
+  via marimo's runtime). Anywidget modules now hydrate via
+  `marimo_book.js`, which trusts data URLs by design. Caveat: the
+  shim doesn't round-trip widget state back to Pyodide — cells
+  reading `widget.value` from an anywidget see the *initial* value;
+  marimo's own `mo.ui.*` controls still round-trip normally.
+>>>>>>> 39c7bd5 (Fix anywidgets rendering empty on WASM-mode pages)
 
 ## [0.1.4] — 2026-04-27
 

--- a/src/marimo_book/transforms/anywidgets.py
+++ b/src/marimo_book/transforms/anywidgets.py
@@ -43,6 +43,7 @@ def rewrite_anywidget_html(
     *,
     cell_source: str | None = None,
     widget_defaults: dict | None = None,
+    keep_marimo_controls: bool = False,
 ) -> str:
     """Rewrite marimo custom elements for static rendering.
 
@@ -58,6 +59,13 @@ def rewrite_anywidget_html(
     2. Literal kwargs parsed out of ``cell_source`` by :mod:`ast`
     3. Anything marimo itself inlined into ``data-initial-value`` (rare for
        static exports — usually just a ``model_id`` reference)
+
+    ``keep_marimo_controls=True`` is set by the WASM render path: in that
+    mode marimo's own runtime serves ``<marimo-slider>`` /
+    ``<marimo-dropdown>`` etc. as live, kernel-backed controls — they
+    must NOT be stripped. We still rewrap anywidgets (because marimo's
+    runtime refuses to load anywidget modules from data URLs) but leave
+    every other custom element in place.
     """
     if (
         "marimo-anywidget" not in raw_html
@@ -84,15 +92,16 @@ def rewrite_anywidget_html(
     for node in list(soup.find_all("marimo-plotly")):
         _rewrap_plotly(node, soup)
 
-    # Pass 3: unwrap or drop <marimo-ui-element> wrappers.
-    for wrapper in list(soup.find_all("marimo-ui-element")):
-        _handle_ui_wrapper(wrapper)
+    if not keep_marimo_controls:
+        # Pass 3: unwrap or drop <marimo-ui-element> wrappers.
+        for wrapper in list(soup.find_all("marimo-ui-element")):
+            _handle_ui_wrapper(wrapper)
 
-    # Pass 4: drop any remaining standalone control elements that slipped
-    # past (e.g. <marimo-slider> appearing at top level outside a wrapper).
-    for ctrl_name in _STANDALONE_CONTROLS:
-        for node in list(soup.find_all(ctrl_name)):
-            node.decompose()
+        # Pass 4: drop any remaining standalone control elements that slipped
+        # past (e.g. <marimo-slider> appearing at top level outside a wrapper).
+        for ctrl_name in _STANDALONE_CONTROLS:
+            for node in list(soup.find_all(ctrl_name)):
+                node.decompose()
 
     # lxml wraps fragments in <html><body>; unwrap for return.
     body = soup.find("body")

--- a/src/marimo_book/transforms/wasm.py
+++ b/src/marimo_book/transforms/wasm.py
@@ -24,6 +24,32 @@ so Material's content area controls width.
 Static reactivity (``precompute.enabled``) is automatically a no-op
 for WASM-rendered pages: the preprocessor's ``_run_precompute`` is
 called only for static-mode entries.
+
+**Anywidget rewrite (the reason this module also imports
+:func:`rewrite_anywidget_html`).** ``MarimoIslandGenerator`` runs
+under marimo's ``ScriptRuntimeContext``, which hardcodes
+``virtual_files_supported=False`` — so every anywidget's ES module
+gets emitted as a ``data:text/javascript;base64,...`` URL. The
+marimo islands runtime then refuses to load those modules
+("Refusing to load anywidget module from untrusted URL"); only
+``@file/...`` URLs are trusted. Result: anywidgets render as empty
+in WASM-mode pages.
+
+We sidestep that by post-processing the islands body with the same
+:func:`rewrite_anywidget_html` we use in static mode — rewrapping
+``<marimo-anywidget>`` to ``<div class="marimo-book-anywidget">``,
+which our ``marimo_book.js`` shim hydrates by importing the data URL
+directly. The cells themselves still go through marimo's islands
+runtime + Pyodide for full Python reactivity; only the anywidget
+modules are mounted by the static shim.
+
+The trade-off: anywidget state set by the shim doesn't round-trip
+back to Pyodide (kernel can't see the in-browser model state), so
+cells that read ``widget.value`` after the user moves an anywidget
+slider see the *initial* value. For widgets driven by ``mo.ui.*``
+controls (which DO round-trip via marimo's runtime) full reactivity
+is preserved — only "anywidget reading anywidget" patterns are
+affected.
 """
 
 from __future__ import annotations
@@ -32,6 +58,8 @@ import asyncio
 from pathlib import Path
 
 from marimo import MarimoIslandGenerator
+
+from .anywidgets import rewrite_anywidget_html
 
 
 def render_wasm_page(py_path: Path, *, display_code: bool = False) -> str:
@@ -53,4 +81,11 @@ def render_wasm_page(py_path: Path, *, display_code: bool = False) -> str:
     asyncio.run(gen.build())
     head = gen.render_head()
     body = gen.render_body(style="")
+    # Re-target anywidgets to our static-shim mount form. See module docstring
+    # for the full rationale; in short, marimo's islands runtime won't load
+    # the data: URLs that ScriptRuntimeContext emits for anywidget modules.
+    # `keep_marimo_controls=True` because in WASM mode the islands runtime
+    # serves <marimo-slider>/<marimo-dropdown>/etc. as live, kernel-backed
+    # controls — they must NOT be stripped (only static export does that).
+    body = rewrite_anywidget_html(body, keep_marimo_controls=True)
     return head + "\n" + body

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -8,9 +8,11 @@ exercises the marimo subprocess + asyncio path and takes a few seconds.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from marimo_book.config import Book
 from marimo_book.preprocessor import Preprocessor
+from marimo_book.transforms import wasm as wasm_module
 
 
 def _wasm_book(book_dir: Path) -> Book:
@@ -109,3 +111,63 @@ def test_static_page_unchanged_alongside_wasm_entry(tmp_path: Path) -> None:
 
     demo = (out_dir / "docs" / "demo.md").read_text(encoding="utf-8")
     assert "@marimo-team/islands" in demo
+
+
+def test_wasm_anywidgets_rewritten_to_static_mount(tmp_path: Path) -> None:
+    """Anywidgets in a WASM-mode page get rewrapped as static mounts.
+
+    Why: ``MarimoIslandGenerator`` runs under ``ScriptRuntimeContext``
+    which hardcodes ``virtual_files_supported=False``, so every
+    anywidget's ES module is emitted as a ``data:text/javascript;base64,…``
+    URL. Marimo's islands runtime explicitly refuses to load those
+    ("Refusing to load anywidget module from untrusted URL"), so
+    anywidgets render as empty in WASM-mode pages by default.
+
+    ``render_wasm_page`` post-processes the islands body with
+    ``rewrite_anywidget_html`` so anywidgets become
+    ``<div class="marimo-book-anywidget">`` mounts that
+    ``marimo_book.js`` hydrates by importing the data URL directly.
+    The cells themselves still go through marimo's runtime + Pyodide
+    for full Python reactivity; only the anywidget modules are
+    mounted by the static shim.
+    """
+    py_path = tmp_path / "demo.py"
+    py_path.write_text(
+        "import marimo\napp = marimo.App()\nif __name__ == '__main__': app.run()\n",
+        encoding="utf-8",
+    )
+
+    fake_body = (
+        '<marimo-island data-cell-id="abc">'
+        "<marimo-anywidget data-js-url='\"data:text/javascript;base64,Zm9vCg==\"'"
+        ' data-initial-value=\'{"model_id":"m1"}\' data-model-id="m1">'
+        "</marimo-anywidget>"
+        "</marimo-island>"
+    )
+
+    class _FakeGen:
+        @staticmethod
+        def from_file(path, *, display_code=False):  # noqa: ARG004
+            return _FakeGen()
+
+        async def build(self):
+            pass
+
+        def render_head(self):
+            return '<script src="https://example/islands.js"></script>'
+
+        def render_body(self, *, style=""):  # noqa: ARG002
+            return fake_body
+
+    with patch.object(wasm_module, "MarimoIslandGenerator", _FakeGen):
+        out = wasm_module.render_wasm_page(py_path)
+
+    # The original <marimo-anywidget> tag is gone; the static mount is in.
+    assert "<marimo-anywidget" not in out
+    assert 'class="marimo-book-anywidget"' in out
+    # The data URL is preserved on the new mount so the JS shim can import it.
+    assert "data-js-url" in out
+    assert "data:text/javascript;base64" in out
+    # The surrounding <marimo-island> wrapper stays — cells still go through
+    # marimo's islands runtime; only the anywidget child got rewrapped.
+    assert "<marimo-island" in out


### PR DESCRIPTION
## Summary

Every anywidget on a WASM-mode page (e.g. dartbrains MR_Physics) was silently disappearing from the DOM. Browser console showed:

\`\`\`
Refusing to load anywidget module from untrusted URL: data:text/javascript;base64,...
\`\`\`

## Root cause

\`MarimoIslandGenerator\` runs under \`ScriptRuntimeContext\`, which hardcodes \`virtual_files_supported=False\` (\`marimo/_runtime/context/script_context.py:165\`). That fallback forces every anywidget's ES module to be emitted as a \`data:text/javascript;base64,...\` URL on \`data-js-url\`.

The marimo islands runtime's trust check (in \`state-DHlRrwyY.js\`):

\`\`\`js
he = function(t) {
  return ... !!(/^(\.?\/)?@file\/[^?#]+$/.test(t) || Lt(t));
};
\`\`\`

…only accepts \`@file/...\` URLs unconditionally; \`data:\` URLs require a trust flag that's not set in the islands build. So \`loadAnywidgetModule\` throws and the widget never instantiates.

## Fix

Post-process the islands body with the same \`rewrite_anywidget_html\` we already use in static mode. \`<marimo-anywidget>\` elements get rewrapped as \`<div class=\"marimo-book-anywidget\">\` mounts, which our existing \`marimo_book.js\` shim hydrates by dynamically importing the inlined data URL — bypassing marimo's trust check entirely.

A new \`keep_marimo_controls\` parameter on \`rewrite_anywidget_html\` makes WASM mode preserve live \`<marimo-slider>\` / \`<marimo-dropdown>\` / \`<marimo-ui-element>\` elements (marimo's runtime serves those as kernel-backed live controls — they must NOT be stripped). Static mode keeps its existing strip-controls behavior unchanged.

## Caveat

The static shim doesn't round-trip anywidget model state back to Pyodide. Cells that read \`widget.value\` from an *anywidget* will see the initial value only. \`mo.ui.*\` controls (slider, dropdown, etc.) still round-trip via marimo's runtime — so any reactive flow driven by \`mo.ui\` continues to work. For dartbrains' MR_Physics, this means: anywidgets render correctly, the \`mo.ui.slider\` controls drive the simulations, and only \"anywidget reading anywidget\" patterns lose reactivity.

## Test plan

- [x] \`pytest -q\` — 122 passed (1 new test added: \`test_wasm_anywidgets_rewritten_to_static_mount\`)
- [x] \`ruff check src/ tests/\` — clean
- [x] \`ruff format --check src/ tests/\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)