### PR TITLE
Typeset math on DOMContentLoaded — fix instant-nav math rendering race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-<<<<<<< HEAD
 - **Precompute slider mounted inline with the wrong cell when an
   upstream cell emitted non-deterministic stderr.** The downstream-
   detection diff in `precompute_page` compared cell bodies byte-for-
@@ -24,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as downstream. Stored cell bodies still keep their stderr — only
   the comparison key is normalized. Surfaced by the dartbrains ICA
   chapter.
-=======
 - **Anywidgets rendered empty on WASM-mode pages.** marimo's
   `MarimoIslandGenerator` runs under `ScriptRuntimeContext` which
   hardcodes `virtual_files_supported=False`, so every anywidget's
@@ -43,7 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shim doesn't round-trip widget state back to Pyodide — cells
   reading `widget.value` from an anywidget see the *initial* value;
   marimo's own `mo.ui.*` controls still round-trip normally.
->>>>>>> 39c7bd5 (Fix anywidgets rendering empty on WASM-mode pages)
+- **Math rendering racing instant-nav.** Material's `document$` is an
+  RxJS `Subject` (not BehaviorSubject) — every page swap (instant-nav
+  click) emits *before* `mathjax.js` subscribes, so MathJax silently
+  never typesets and arithmatex spans render as raw `\(...\)` /
+  `\[...\]` LaTeX text. Same bug class as the v0.1.1 precompute slider
+  boot race, fixed the same way: belt-and-suspenders typeset on
+  DOMContentLoaded *and* every `document$` emission, both idempotent.
 
 ## [0.1.4] — 2026-04-27
 

--- a/src/marimo_book/assets/mathjax.js
+++ b/src/marimo_book/assets/mathjax.js
@@ -12,8 +12,27 @@ window.MathJax = {
   }
 };
 
-document$.subscribe(() => {
+// Belt-and-suspenders typeset boot, mirroring the precompute shim.
+// Material's `document$` is an RxJS Subject (not BehaviorSubject), so a
+// late subscriber misses the initial emission — that's exactly what
+// happens on a direct page load *and* on every instant-nav swap, where
+// the new page body lands before any subscriber is ready. With only
+// `document$.subscribe`, MathJax silently never runs and arithmatex
+// spans render as raw `\(...\)` LaTeX text.
+//
+// Fix: also typeset on DOMContentLoaded / immediate, *and* on every
+// `document$` emission. typesetPromise is idempotent over already-
+// rendered output, so calling it twice on the same page is harmless.
+function typesetMath() {
   if (window.MathJax && MathJax.typesetPromise) {
     MathJax.typesetPromise();
   }
-});
+}
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", typesetMath);
+} else {
+  typesetMath();
+}
+if (typeof document$ !== "undefined" && document$.subscribe) {
+  document$.subscribe(typesetMath);
+}


### PR DESCRIPTION
## Symptom

Reproduced via playwright on https://marimobook.org/:

1. Hit \`/\` (home page).
2. Click \"Authoring\" via Material's instant-nav.
3. \`document.querySelectorAll('.arithmatex')\` finds 2 spans, both with raw LaTeX text and **no \`mjx-container\` child** — MathJax never typeset them.

A direct full reload of \`/authoring/\` rendered them fine.

## Root cause

Same RxJS Subject boot-race that bit the precompute slider in v0.1.1.

Material's \`document$\` is a Subject (not a BehaviorSubject), so a subscriber added *after* the initial emission misses it. With only \`document$.subscribe(typeset)\`, the late attach during instant-nav swaps never fires.

## Fix

Belt-and-suspenders typeset boot, mirroring the pattern already in \`marimo_book.js\`:

\`\`\`js
function typesetMath() {
  if (window.MathJax && MathJax.typesetPromise) MathJax.typesetPromise();
}
if (document.readyState === \"loading\") {
  document.addEventListener(\"DOMContentLoaded\", typesetMath);
} else {
  typesetMath();
}
if (typeof document$ !== \"undefined\" && document$.subscribe) {
  document$.subscribe(typesetMath);
}
\`\`\`

\`typesetPromise\` is idempotent over already-rendered output, so the double-call on first paint is harmless.

## Test plan

Pure JS asset change — no unit test. After merge + docs deploy:

- [ ] Navigate https://marimobook.org/ → click \"Authoring\" → confirm \`x^2\` and the \`\\hat{\\boldsymbol{\\beta}}\` block render as actual math (not raw LaTeX text)
- [ ] Same for \`/example/\` (the math-cells section)
- [ ] Direct full-load of those pages still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)