### PR TITLE
Docs polish: bundle autorefs, reorder TOC, expand book_yml.md reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`mkdocs-autorefs` is now a base dependency.** It used to live
+  behind `pip install 'marimo-book[autorefs]'`, which was a recurring
+  trip-up — books with `cross_references: true` in `book.yml` would
+  build fine on CI (where the extra was installed) and then silently
+  drop the cross-ref behavior locally. The package is small and pure
+  Python, so promoting it costs nothing. The `[autorefs]` extra is
+  kept as an empty alias so existing install scripts keep working.
+- **Docs TOC: `widgets.md` (the Anywidgets reference) now sits
+  immediately before the `anywidget_demo` page** under Authoring, so
+  reference docs and the live demo are next to each other.
+
 ### Fixed
 
 - **Precompute slider mounted inline with the wrong cell when an
@@ -48,6 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `\[...\]` LaTeX text. Same bug class as the v0.1.1 precompute slider
   boot race, fixed the same way: belt-and-suspenders typeset on
   DOMContentLoaded *and* every `document$` emission, both idempotent.
+
+### Documentation
+
+- `book_yml.md` reference now covers the full schema: `analytics`
+  (provider + property), the complete `precompute` block (all five
+  caps + `exclude_pages`), `url` (canonical site URL), `bibliography`
+  + `cite_style`. Several fields were missing or sketched in
+  one-liners.
+- Drop the "requires `pip install 'marimo-book[autorefs]'`"
+  reminders now that the plugin ships in the base install.
 
 ## [0.1.4] — 2026-04-27
 

--- a/docs/book.yml
+++ b/docs/book.yml
@@ -37,8 +37,9 @@ dependencies:
 social_cards: true
 
 # Resolve cross-page heading references. Lets us write `[Anywidgets][]`
-# and have it auto-link to whatever page has that heading. Requires
-# `pip install 'marimo-book[autorefs]'`.
+# and have it auto-link to whatever page has that heading. As of
+# marimo-book 0.1.5 mkdocs-autorefs ships in the base install, so no
+# extra is needed — just flip this flag.
 cross_references: true
 
 # Auto-include the repo-root CHANGELOG.md as a "Changelog" page in the

--- a/docs/content/authoring.md
+++ b/docs/content/authoring.md
@@ -187,7 +187,7 @@ The [Anywidgets][] page covers the JS shim in detail.
 
 The [Anywidgets][] page covers the JS shim in detail.
 
-This requires the optional plugin: `pip install 'marimo-book[autorefs]'`.
+No extra install needed — `mkdocs-autorefs` ships with `marimo-book` as of 0.1.5; just opt in per book via `cross_references: true` in `book.yml`.
 
 **Term tooltips.** Define an abbreviation once and it becomes a hover
 tooltip everywhere on the page:

--- a/docs/content/book_yml.md
+++ b/docs/content/book_yml.md
@@ -57,8 +57,8 @@ analytics:
 # External-link check (opt-in, requires marimo-book[linkcheck])
 check_external_links: false
 
-# Cross-page heading references via mkdocs-autorefs (opt-in,
-# requires marimo-book[autorefs])
+# Cross-page heading references via mkdocs-autorefs (bundled with
+# marimo-book — no extra install needed; just flip this flag).
 cross_references: false
 
 # Auto-include CHANGELOG.md from the book root as a "Changelog" page
@@ -112,10 +112,11 @@ That's enough to build. Every other field uses a sensible default.
 | `title` | string | **required** | Shown in the header, browser tab, search index |
 | `description` | string | `None` | Used as `<meta>` description and search preview |
 | `authors[]` | list of `Author` | `[]` | See *Authors* below |
-| `copyright` | string | `None` | Footer copyright |
+| `copyright` | string | `None` | Footer copyright. HTML allowed — useful for funding lines + linked author names |
 | `license` | string | `None` | SPDX identifier (`MIT`, `CC-BY-SA-4.0`) |
 | `repo` | URL | `None` | Enables "Edit on GitHub" links + launch buttons |
 | `branch` | string | `main` | Branch that `repo` links target |
+| `url` | URL | `None` | Canonical site URL. Used for absolute links in OpenGraph cards and the search index |
 | `doi` | string | `None` | Renders as a badge on the landing page |
 
 Each author supports `name` (required), `orcid`, `affiliation`, and
@@ -168,7 +169,44 @@ override these defaults. See [Authoring → Anywidgets](widgets.md).
 ### Analytics
 
 Opt-in Plausible or Google Analytics. Injected via Material for MkDocs'
-`extra.analytics` block.
+`extra.analytics` block; Material auto-injects the gtag.js / Plausible
+script on every page.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `analytics.provider` | `plausible` \| `google` \| `none` | `none` | Off by default. Both providers live in the Material analytics integration |
+| `analytics.property` | string | `None` | GA4 Measurement ID (`G-XXXXXXXXXX`) for Google, or domain (`yoursite.org`) for Plausible. Universal Analytics IDs (`UA-...`) are not supported — Google retired UA on 2023-07-01 |
+
+```yaml
+analytics:
+  provider: google
+  property: G-XXXXXXXXXX
+```
+
+### Static reactivity (`precompute`)
+
+Re-renders the notebook once per discrete-widget value at build time
+and ships a JSON lookup table the JS shim swaps on slider input. Off
+by default; opt in per book.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `precompute.enabled` | bool | `false` | Flip on to scan every `.py` page for `mo.ui.slider(steps=...)` / `mo.ui.dropdown` / `mo.ui.switch` / `mo.ui.radio` candidates |
+| `precompute.max_values_per_widget` | int | `50` | Skip a widget whose value set exceeds this. Cheap cap, checked before any execution |
+| `precompute.max_combinations_per_page` | int | `200` | Across all widgets on a page (cartesian product when multiple widgets share a downstream cell). Cheap cap |
+| `precompute.max_seconds_per_page` | int | `60` | Wall-clock budget per page. The orchestrator extrapolates from the first export and aborts if projected runtime exceeds. Bump to 600+ for heavy chapters (whole-brain decomposition, fMRI processing, etc.) |
+| `precompute.max_bytes_per_page` | int | `10485760` (10 MB) | Inline-table budget. Bump to 50 MB for chapters whose per-render output is large (e.g. inline brain HTML viewers) |
+| `precompute.exclude_pages[]` | list of paths | `[]` | Pages listed here render every widget as static even when the global flag is on |
+
+See [Building → Static reactivity](building.md#static-reactivity-precompute)
+for the full pipeline + tuning guide.
+
+### Bibliography
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `bibliography` | list of paths | `[]` | BibTeX files to load. Inline list shorthand also accepted (`bibliography: [refs.bib, more.bib]`) |
+| `cite_style` | `apa` \| `numbered` | `apa` | Citation rendering format |
 
 ### Defaults
 

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -194,7 +194,7 @@ pip install 'marimo-book[social,autorefs,linkcheck,pdf]'
 | Flag | What it does | Extra |
 |---|---|---|
 | `social_cards: true` | Material's `social` plugin auto-generates per-page OpenGraph / Twitter card PNGs and injects the matching `<meta>` tags | `marimo-book[social]` (also needs system `libcairo2 libpango-1.0-0 libpangocairo-1.0-0`) |
-| `cross_references: true` | `mkdocs-autorefs` resolves `[Heading text][]` to whichever page contains that heading — the MkDocs analog of MyST `{ref}` | `marimo-book[autorefs]` |
+| `cross_references: true` | `mkdocs-autorefs` resolves `[Heading text][]` to whichever page contains that heading — the MkDocs analog of MyST `{ref}` | None — bundled with `marimo-book` |
 | `check_external_links: true` | `htmlproofer` HEAD-checks every `<a href>` and `<img src>` against the live web | `marimo-book[linkcheck]` |
 | `include_changelog: true` | Preprocessor copies `CHANGELOG.md` from the book root (or its parent) into the staged tree and appends a "Changelog" entry to the nav | None |
 | `pdf_export: true` | `mkdocs-with-pdf` renders the entire book through WeasyPrint into `_site/pdf/book.pdf` and adds a "Download PDF" link to the page footer | `marimo-book[pdf]` (also needs the cairo + pango system libs above) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,13 @@ dependencies = [
     "nbformat>=5.0",
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
+    # Cross-reference resolution by heading text. Pure Python, ~150 KB,
+    # no system deps — the friction of remembering to `pip install
+    # 'marimo-book[autorefs]'` was tripping up enough users that we
+    # promoted it to a base dep. Books opt in per-book via
+    # `cross_references: true` in `book.yml`; if the flag is off, the
+    # plugin is loaded but no-ops.
+    "mkdocs-autorefs>=1.0",
     "pymdown-extensions>=10.7",
     "watchdog>=4.0",
 ]
@@ -62,13 +69,11 @@ linkcheck = [
 social = [
     "mkdocs-material[imaging]>=9.5",
 ]
-# Opt-in cross-reference resolution by heading text — the MkDocs analog
-# of MyST `{ref}`. Enable via `cross_references: true` in book.yml and
-# install this extra. Lets you write `[Heading text][]` and have it
-# resolve to whatever page contains that heading.
-autorefs = [
-    "mkdocs-autorefs>=1.0",
-]
+# Compatibility alias — `mkdocs-autorefs` is now a base dep
+# (cross_references works without an extra). This entry is kept so
+# `pip install 'marimo-book[autorefs]'` still succeeds for existing
+# install scripts; it's a no-op since the package is already installed.
+autorefs = []
 # Opt-in single-PDF export of the entire book. Enable via
 # `pdf_export: true` in book.yml and install this extra. Renders the
 # built site through WeasyPrint into a single PDF + adds a "Download


### PR DESCRIPTION
## Summary

Three docs-quality changes:

1. **\`mkdocs-autorefs\` is now a base dep** (\`pyproject.toml\`). Lived behind \`pip install 'marimo-book[autorefs]'\` and was a recurring trip-up — \`cross_references: true\` in \`book.yml\` would silently no-op locally if the extra wasn't installed, even when CI built fine. Package is small and pure-Python; promoting it costs nothing. Kept \`[autorefs]\` extra as an empty alias for backward compat.
2. **Docs TOC reorder**: \`widgets.md\` (the Anywidgets reference) now sits immediately before the \`anywidget_demo\` page under Authoring. Previously they were three entries apart — readers landing on the demo had to flip back two pages to find the explanation.
3. **book_yml.md reference expansion**: new \`precompute\` section (all five caps + \`exclude_pages\`), expanded \`analytics\` (provider + property + GA4 vs UA caveat), \`url\` (canonical site URL) added to metadata table, new \`bibliography\` + \`cite_style\` block. Several schema fields were missing or one-line sketches.

Touched-up \`authoring.md\` and \`building.md\` to match the new "no extra needed" autorefs story.

## Test plan

- [x] \`pytest -q\` — 121 passed
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [ ] After merge + docs deploy: \`https://marimobook.org/book_yml/\` shows the new \`precompute\` and \`analytics\` schema tables; the Authoring sidebar lists \`Anywidgets\` (widgets.md) directly before \`Anywidget demo\` (anywidget_demo.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)