### PR TITLE
CI: cache marimo-book docs build between deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,18 @@ jobs:
         run: pip install -e '.[linkcheck,social,autorefs,pdf]'
       - name: Install demo notebook deps (drawdata used by anywidget_demo.py)
         run: pip install drawdata anywidget
+      # Restore the marimo-book build cache so unchanged chapters skip
+      # re-rendering. Cache lives next to book.yml, so for the
+      # self-hosted docs that's `docs/.marimo_book_cache/`.
+      # Keyed on docs/, src/ (so that a packaging change rebuilds the
+      # output), and pyproject.toml (so dep upgrades invalidate).
+      - name: Restore marimo-book build cache
+        uses: actions/cache@v4
+        with:
+          path: docs/.marimo_book_cache
+          key: docs-mb-${{ runner.os }}-${{ hashFiles('docs/**', 'src/**', 'pyproject.toml') }}
+          restore-keys: |
+            docs-mb-${{ runner.os }}-
       - name: Build docs
         run: marimo-book build -b docs/book.yml --strict
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

Mirrors the \`actions/cache@v4\` setup I'm proposing for dartbrains (ljchang/dartbrains#61). The docs site is itself built with marimo-book, so it benefits from the same content-addressed \`BuildCache\` that the rest of the ecosystem uses.

The docs are smaller than dartbrains so the absolute savings are modest, but every CI run was paying for cells that hadn't drifted.

## Details

- **Cache path**: \`docs/.marimo_book_cache\` — \`BuildCache\` writes its manifest next to \`book.yml\`, which for the self-hosted docs is \`docs/book.yml\`.
- **Key**: \`docs-mb-\${{ runner.os }}-\${{ hashFiles('docs/**', 'src/**', 'pyproject.toml') }}\`. \`src/\` is in the key because a packaging change (e.g. an anywidget rewrite tweak in \`marimo_book/transforms/\`) does change the rendered output, and we want the cache to invalidate accordingly. \`pyproject.toml\` covers dep upgrades.
- **\`restore-keys\`**: falls back to the most recent partial-match cache; \`BuildCache\` then validates each entry against current source hashes per file, re-rendering only what's drifted.

## Test plan

- [ ] First push after merge: full build runs, cache saves at end of run
- [ ] Subsequent push that touches only \`docs/content/quickstart.md\`: \`pages_cached\` count in build report shows N-1 of N pages cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)