### PR TITLE
Date CHANGELOG for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.5] — 2026-04-27
 
 ### Changed
 


### PR DESCRIPTION
Tiny release-flow PR: dates the [Unreleased] section to today (2026-04-27) ahead of cutting v0.1.5. After merge, publish the GitHub release with tag `v0.1.5` to fire the publish workflow.