### PR TITLE
Stop clobbering window.MathJax on instant-nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Math still didn't render after instant-nav** despite the v0.1.5
+  typeset-on-DOMContentLoaded fix. Real cause: `mathjax.js` was
+  unconditionally assigning `window.MathJax = {tex, options}`, which
+  Material's instant-nav re-executes on every page swap — overwriting
+  the already-initialized MathJax library state (typesetPromise,
+  startup, etc.) with a stub config object. The very first page
+  rendered because the library completed its typeset before the
+  clobber; every navigation after that left arithmatex spans as raw
+  `\(...\)` text because typesetPromise was gone. Wrap the assignment
+  in `if (!window.MathJax)` so the config is set once and the live
+  library is never overwritten.
+
 ## [0.1.5] — 2026-04-27
 
 ### Changed

--- a/src/marimo_book/assets/mathjax.js
+++ b/src/marimo_book/assets/mathjax.js
@@ -1,28 +1,35 @@
 // MathJax config expected by pymdownx.arithmatex (generic mode).
-window.MathJax = {
-  tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
-    processEscapes: true,
-    processEnvironments: true
-  },
-  options: {
-    ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
-  }
-};
-
-// Belt-and-suspenders typeset boot, mirroring the precompute shim.
-// Material's `document$` is an RxJS Subject (not BehaviorSubject), so a
-// late subscriber misses the initial emission — that's exactly what
-// happens on a direct page load *and* on every instant-nav swap, where
-// the new page body lands before any subscriber is ready. With only
-// `document$.subscribe`, MathJax silently never runs and arithmatex
-// spans render as raw `\(...\)` LaTeX text.
 //
-// Fix: also typeset on DOMContentLoaded / immediate, *and* on every
-// `document$` emission. typesetPromise is idempotent over already-
-// rendered output, so calling it twice on the same page is harmless.
+// CRITICAL: only set window.MathJax if it isn't already defined. Material's
+// instant-nav re-executes <body> scripts on every page swap, which means
+// this file runs again — and unconditionally assigning
+// `window.MathJax = {tex, options}` would overwrite the live library
+// (with its typesetPromise / startup / etc.) with a stub config object,
+// silently breaking every subsequent re-typeset. The math on the first
+// page renders because MathJax completes its initial typeset *before*
+// the post-load instant-nav clobber; click any link and the new page's
+// arithmatex spans stay as raw `\(...\)` text.
+if (!window.MathJax) {
+  window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+}
+
+// Belt-and-suspenders typeset boot. typesetPromise is idempotent over
+// already-rendered output, so calling it twice on the same page is
+// harmless. The DOMContentLoaded path covers direct loads where the
+// MathJax library hasn't quite finished setup by the time document$
+// would normally have emitted; document$.subscribe covers Material's
+// instant-nav swaps where DOMContentLoaded does NOT re-fire.
 function typesetMath() {
   if (window.MathJax && MathJax.typesetPromise) {
     MathJax.typesetPromise();


### PR DESCRIPTION
## What v0.1.5's MathJax fix missed

v0.1.5 added \`DOMContentLoaded\` + \`document$.subscribe\` hooks to typeset math after instant-nav. Necessary, but not sufficient.

The actual reason instant-nav math still doesn't render: this file unconditionally did

\`\`\`js
window.MathJax = { tex: {...}, options: {...} };
\`\`\`

at the top of the script. Material's instant-nav **re-executes \`<body>\`-loaded scripts on every page swap**, so this ran again on each navigation — overwriting the already-initialized MathJax library state (\`typesetPromise\`, \`startup\`, the rest of the runtime API) with a stub config object. The hook then short-circuited at \`if (MathJax.typesetPromise)\` because the method no longer existed.

First-page math worked only because the MathJax library finished its initial typeset *before* mathjax.js re-ran. Click any link → runtime state gone → typeset hook silently no-ops.

## Verified by playwright on https://marimobook.org/

Reproduced after the v0.1.5 deploy:

\`\`\`text
Home → click Authoring → window.MathJax keys: ["tex", "options"]
                          typesetPromise: undefined
                          startup: undefined
                          arithmatex spans: 2 present, 0 rendered
\`\`\`

## Fix

Guard the config assignment so it runs once:

\`\`\`js
if (!window.MathJax) {
  window.MathJax = { tex: {...}, options: {...} };
}
\`\`\`

First script execution sets the config. The MathJax CDN script picks it up, initializes, adds \`typesetPromise\`. On every subsequent instant-nav re-execution, the guard skips and the live library is preserved. typesetMath now finds \`typesetPromise\` and re-typesets the new body.

## Test plan

- [ ] After deploy: load https://marimobook.org/ → click \"Authoring\" → \`document.querySelectorAll('.arithmatex mjx-container').length\` should equal \`document.querySelectorAll('.arithmatex').length\`
- [ ] Same check for /example/ via instant-nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)