### PR TITLE
Fix launch-button URLs when book.yml lives in a repo subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **GitHub / molab / download launch-button URLs 404'd when the book
+  lived in a subdirectory of its repo.** The URL builders prepended
+  the source path *relative to the book root* to `<repo>/blob/<branch>/`,
+  so a book at `docs/book.yml` pointed to
+  `<repo>/blob/<branch>/content/<file>` instead of the correct
+  `<repo>/blob/<branch>/docs/content/<file>`. The preprocessor now
+  walks up from the book directory to the enclosing `.git` and
+  prepends that relative path. Books at the repo root (the typical
+  case) are unaffected.
+
 ## [0.1.7] — 2026-04-28
 
 ### Fixed

--- a/src/marimo_book/launch_buttons.py
+++ b/src/marimo_book/launch_buttons.py
@@ -17,13 +17,23 @@ from urllib.parse import urlparse
 from .config import Book
 
 
-def render_button_row(book: Book, source_file: Path) -> str:
+def render_button_row(book: Book, source_file: Path, *, repo_subpath: str = "") -> str:
     """Return an HTML string with a row of enabled launch buttons.
 
     Returns an empty string if none are enabled for this page.
+
+    ``repo_subpath`` is the path from the repo root to the book root,
+    posix-style, with no trailing slash (e.g. ``"docs"`` when the book
+    lives at ``docs/`` in the repo). It's prepended to the source path
+    in every URL so the GitHub / molab / raw-download links resolve to
+    the actual file. Empty when the book lives at the repo root (the
+    typical case — most consumers run ``marimo-book`` against a
+    book.yml at the repo top level).
     """
     buttons: list[str] = []
     source_posix = source_file.as_posix()
+    if repo_subpath:
+        source_posix = f"{repo_subpath.strip('/')}/{source_posix}"
 
     if book.launch_buttons.molab and source_file.suffix == ".py":
         url = _molab_url(book, source_posix)

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -571,6 +571,33 @@ def _iter_file_entries(toc: list) -> list[FileEntry]:
     return out
 
 
+def _book_subpath_in_repo(book_dir: Path) -> str:
+    """Return the book's path relative to its enclosing git repo, or "".
+
+    Walks upward from ``book_dir`` looking for a ``.git`` directory or
+    file (the latter for git worktrees). When found, returns the
+    book's path relative to that repo root, posix-style. When not
+    found (book.yml not inside a checked-out repo), returns an empty
+    string and launch-button URLs fall back to assuming the book is
+    at the repo root — the historical behavior.
+
+    Used by ``stage_page`` to make the GitHub / molab / download
+    launch buttons resolve correctly when ``book.yml`` lives in a
+    subdirectory of its repo (e.g. ``docs/`` for marimo-book's own
+    self-hosted documentation). Without this, a per-page GitHub
+    button on ``content/index.md`` would link to
+    ``https://github.com/<owner>/<repo>/blob/<branch>/content/index.md``,
+    which 404s because the actual path is
+    ``docs/content/index.md``.
+    """
+    book_dir = book_dir.resolve()
+    for p in (book_dir, *book_dir.parents):
+        if (p / ".git").exists():
+            rel = book_dir.relative_to(p)
+            return rel.as_posix() if rel != Path(".") else ""
+    return ""
+
+
 # --- Single-page staging ----------------------------------------------------
 
 
@@ -593,7 +620,9 @@ def stage_page(
     dst = docs_dir / rel_under_docs
     dst.parent.mkdir(parents=True, exist_ok=True)
 
-    buttons = render_button_row(book, Path(entry.file))
+    buttons = render_button_row(
+        book, Path(entry.file), repo_subpath=_book_subpath_in_repo(book_dir)
+    )
 
     mode = entry.effective_mode(book.defaults.mode)
     if src_abs.suffix == ".py":

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -99,6 +99,31 @@ def test_launch_buttons_default_placement_header() -> None:
     assert 'data-placement="header"' in row
 
 
+def test_launch_buttons_repo_subpath_prepended_when_book_in_subdir() -> None:
+    """When the book lives in a subdirectory of its repo (e.g. docs/), the
+    GitHub / molab / raw URLs must include that subpath, otherwise links
+    404 against the actual repo layout. Case in point: marimo-book's own
+    docs at docs/book.yml — without this, the GitHub button on
+    /authoring/ would link to ``.../blob/main/content/authoring.md``
+    instead of the correct ``.../blob/main/docs/content/authoring.md``.
+    """
+    b = _book_with_repo()
+    row = render_button_row(b, Path("content/x.py"), repo_subpath="docs")
+    assert "molab.marimo.io/github/owner/repo/blob/v2/docs/content/x.py" in row
+    assert "github.com/owner/repo/blob/v2/docs/content/x.py" in row
+    assert "raw.githubusercontent.com/owner/repo/v2/docs/content/x.py" in row
+
+
+def test_launch_buttons_repo_subpath_empty_keeps_legacy_behavior() -> None:
+    """Empty repo_subpath (the default for books at repo root) leaves URLs
+    unchanged — ensures we don't regress dartbrains-style book layouts
+    where book.yml IS at the repo root."""
+    b = _book_with_repo()
+    row = render_button_row(b, Path("content/x.py"), repo_subpath="")
+    assert "github.com/owner/repo/blob/v2/content/x.py" in row
+    assert "/blob/v2/docs/content" not in row  # no leaked prefix
+
+
 # --- end-to-end marimo_export -----------------------------------------------
 
 


### PR DESCRIPTION
## Symptom

The GitHub launch button on https://marimobook.org/ links to \`https://github.com/ljchang/marimo-book/blob/main/content/index.md\` — which 404s, because the file is actually at \`docs/content/index.md\` in the repo. Same shape for molab and download buttons.

## Cause

\`render_button_row\` takes the source path *relative to the book root* (\`content/index.md\`) and joins it to \`<repo>/blob/<branch>/\`. That works when book.yml is at the repo root (every scaffolded book, dartbrains, etc.) but breaks for marimo-book's own docs at \`docs/book.yml\`, where the actual file path includes a \`docs/\` prefix.

## Fix

\`render_button_row\` accepts a \`repo_subpath\` kwarg. \`stage_page\` computes it once via a new helper \`_book_subpath_in_repo\` that walks upward from the book directory looking for a \`.git\` (directory or file — the latter for git worktrees), then returns the book's path relative to that repo root. URL builders prepend the subpath.

- Book at repo root → \`_book_subpath_in_repo\` returns \`\"\"\` → URLs unchanged. dartbrains and every scaffolded book see no behavior change.
- Book in a subdir → returns \`\"docs\"\` (or whatever) → URLs become correctly-formed.
- Book outside a git checkout → returns \`\"\"\` → falls back to today's (possibly-broken) behavior, but in practice this only happens for ad-hoc local builds.

## Test plan

- [x] \`pytest -q\` — 126 passed (2 new tests added)
- [x] \`ruff check\` — clean
- [ ] After deploy: GitHub button on https://marimobook.org/ links to \`https://github.com/ljchang/marimo-book/blob/main/docs/content/index.md\` (HTTP 200, not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)