### PR TITLE
Center sidebar logo + restore notebook author byline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `molab` / version control. New `dependencies.{auto_pep723, pin,
   extras, overrides, requires_python}` fields in `book.yml`.
 
+### Changed
+
+- **Sidebar logo (`logo_placement: sidebar`) is now horizontally
+  centered in the sidebar column** instead of left-flush. The previous
+  asymmetric padding tried to align the logo with chapter section
+  labels, but the labels' own indentation meant they never quite
+  matched anyway. Centering reads more naturally as a banner above
+  the nav.
+
+### Fixed
+
+- **Per-notebook `*Written by …*` attribution lines are no longer
+  stripped from rendered pages.** The export transform was filtering
+  any line matching that pattern from every markdown cell, on the
+  assumption that book-level `authors:` would surface per-page
+  bylines through the page header — but that rendering path was never
+  wired up, so attributions were silently lost. The line now passes
+  through and renders as the italic byline under the chapter title,
+  matching the original Jupyter Book convention.
+
 ## [0.1.8] — 2026-04-28
 
 ### Fixed

--- a/src/marimo_book/assets/logo_sidebar.css
+++ b/src/marimo_book/assets/logo_sidebar.css
@@ -17,22 +17,18 @@
 
   /* Promote the nav drawer header (which holds the logo) into a visible
    * banner above the primary sidebar nav. Material hides this on desktop
-   * by default; we restore it as a left-aligned container that shows
-   * only the logo image (the site name is already in the header bar —
-   * no point in repeating it here).
+   * by default; we restore it as a centered container that shows only
+   * the logo image (the site name is already in the header bar — no
+   * point in repeating it here).
    *
-   * Two critical bits:
-   *  1. background-color matches the sidebar background. The title
-   *     stays sticky (Material default), so without an opaque bg the
-   *     chapter list scrolls *behind* the logo and you see them through
-   *     it.
-   *  2. left-aligned padding so the logo lines up with the chapter
-   *     section labels and roughly with the header's site title. */
+   * background-color matches the sidebar background because the title
+   * stays sticky (Material default); without an opaque bg the chapter
+   * list scrolls *behind* the logo and you see them through it. */
   .md-sidebar--primary .md-nav--primary > .md-nav__title {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    padding: 1rem 0.6rem 0.75rem 1.1rem;
+    justify-content: center;
+    padding: 1rem 0.6rem 0.75rem 0.6rem;
     height: auto;
     background-color: var(--md-default-bg-color);
     box-shadow: none;

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -258,13 +258,7 @@ def _render_markdown_cell(cell: dict, *, strip_duplicate_title: bool) -> str:
     src = _as_str(cell.get("source", "")).strip("\n")
     if not src:
         return ""
-    # The plan strips "*Written by …*" attribution lines from the first
-    # markdown cell because book.yml already renders authors in the page
-    # header. Apply to every markdown cell; the pattern is narrow enough.
-    lines = [
-        line for line in src.split("\n") if not re.match(r"^\s*\*Written [Bb]y\s+.+\*\s*$", line)
-    ]
-    return "\n".join(lines).strip("\n")
+    return src
 
 
 def _render_code_cell(cell: dict, *, widget_defaults: dict | None = None) -> str:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,6 +8,7 @@ from marimo_book.config import Book
 from marimo_book.launch_buttons import render_button_row
 from marimo_book.transforms.callouts import render_callout_html
 from marimo_book.transforms.marimo_export import (
+    _render_markdown_cell,
     _render_mime_bundle,
     cells_to_markdown,
     export_notebook,
@@ -147,6 +148,26 @@ def test_plotly_rewrap_emits_static_mount() -> None:
     assert 'class="marimo-book-plotly"' in out
     assert "marimo-plotly" not in out.replace("marimo-book-plotly", "")  # no original tag left
     assert "data-figure=" in out
+
+
+def test_markdown_cell_preserves_written_by_byline() -> None:
+    """Per-notebook ``*Written by …*`` attribution lines must survive
+    rendering — they are the canonical Jupyter-Book-era byline and the
+    only place per-chapter authorship is recorded in dartbrains."""
+    cell = {
+        "cell_type": "markdown",
+        "source": "# Introduction to GLM\n*Written by Luke Chang*\n\nBody text.",
+    }
+    out = _render_markdown_cell(cell, strip_duplicate_title=False)
+    assert "*Written by Luke Chang*" in out
+    assert "# Introduction to GLM" in out
+    assert "Body text." in out
+
+
+def test_markdown_cell_passes_through_when_no_byline() -> None:
+    cell = {"cell_type": "markdown", "source": "# Title\n\nJust prose, no byline.\n"}
+    out = _render_markdown_cell(cell, strip_duplicate_title=False)
+    assert out == "# Title\n\nJust prose, no byline."
 
 
 def test_anywidget_escaped_under_text_markdown_routes_to_html() -> None:


### PR DESCRIPTION
## Summary

- **Sidebar logo (`logo_placement: sidebar`) is now horizontally centered** in the sidebar column instead of left-flush. The previous asymmetric padding tried to align the logo with chapter section labels, but the labels' own indentation meant they never quite matched anyway. Centering reads more naturally as a banner above the nav.
- **Per-notebook `*Written by …*` attribution lines are no longer stripped** from rendered pages. The export transform in `_render_markdown_cell` was filtering any line matching that pattern from every markdown cell, on the assumption that book-level `authors:` would surface per-page bylines through the page header — but that rendering path was never wired up (`Defaults.hide_author_line` in `config.py:220` is dead code, never read anywhere). Net effect: attributions were silently lost. The line now passes through and renders as the italic byline under the chapter title, matching the original Jupyter Book convention.

DartBrains chapters that exercise the byline path: `GLM.py`, `Connectivity.py`, `Introduction_to_Programming.py`, `fmriprep_on_discovery.md` (multi-author: "Mijin Kwon, Era Wu, & Luke Chang"), and several others.

## Test plan

- [x] `pytest tests/test_transforms.py -q` — 15/15 pass (incl. 2 new tests covering byline-preserved + no-byline-passthrough)
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` — clean
- [x] End-to-end build against DartBrains: `_site/stylesheets/logo_sidebar.css` shows `justify-content: center`; `_site/GLM/index.html`, `_site/Connectivity/index.html`, and `_site/fmriprep_on_discovery/index.html` all render the expected "Written by …" byline under the chapter title
- [x] CI green (`test (3.11/3.12/3.13)`, `build`, `docs`)

## Out of scope

- Adding a `book.yml` field for per-page authors (TOC override). Defer until there's a concrete need (Open Graph cards, search facets) that the in-notebook line can't satisfy.
- Wiring up or removing the dead `Defaults.hide_author_line` field. Worth a separate cleanup.
- Reworking `_render_markdown_cell`'s unused `strip_duplicate_title` parameter.