### PR TITLE
WASM bootstrap: insert after with app.setup: blocks

### DIFF
--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -322,22 +322,28 @@ def _maybe_stage_with_pep723(
     # have something to install.
     new_source = source
     if wasm_bootstrap and deps:
+        # Setup blocks run before any @app.cell, so our sentinel-based
+        # ordering can't get the install in first. Pyodide auto-loads
+        # *bundled* scientific packages (numpy, pandas, scipy, sklearn,
+        # matplotlib, …) via ``loadPackagesFromImports`` during cell
+        # parsing, so a setup block whose imports are all bundled works
+        # fine. A setup block with any non-bundled import (the
+        # dartbrains-tools / nltools class) will fail before our
+        # bootstrap can run. We can't tell the two apart cheaply
+        # (there's no maintained Pyodide-bundle list in our pipeline),
+        # so on detection of any setup block we still inject the
+        # bootstrap (covers cells outside the setup block) and emit an
+        # advisory warning so the author can audit their setup imports.
         if has_app_setup_block(source):
-            # Setup blocks run before any @app.cell, so our sentinel-based
-            # ordering can't get the install in first. Fall back to skipping
-            # the bootstrap for this notebook + a visible warning so the
-            # author knows their non-bundled imports won't auto-install in
-            # the browser.
             print(
-                f"  warning: {src_abs.name} uses `with app.setup:` — "
-                "WASM micropip bootstrap skipped for this page. Move "
-                "non-Pyodide-bundled imports (e.g. nltools, dartbrains-tools) "
-                "out of the setup block into a regular `@app.cell` so the "
-                "auto-install can run before them.",
+                f"  note: {src_abs.name} uses `with app.setup:`. Setup-block "
+                "imports run before WASM micropip install; make sure every "
+                "import there is in Pyodide's bundled package set, or move "
+                "non-bundled imports (nltools, dartbrains-tools, etc.) into "
+                "a regular `@app.cell` so the auto-install can run first.",
                 file=sys.stderr,
             )
-        else:
-            new_source = inject_micropip_bootstrap(new_source, deps)
+        new_source = inject_micropip_bootstrap(new_source, deps)
     new_source = write_pep723_block(new_source, deps, requires_python=requires_python)
 
     with tempfile.TemporaryDirectory(prefix="marimo_book_pep723_", dir=src_abs.parent) as tmp_dir:

--- a/src/marimo_book/transforms/pep723.py
+++ b/src/marimo_book/transforms/pep723.py
@@ -366,16 +366,6 @@ def inject_micropip_bootstrap(source: str, packages: Sequence[str]) -> str:
     except SyntaxError:
         return source
 
-    # Notebooks using ``with app.setup:`` aren't supported by this
-    # transform: marimo runs the setup block before *any* ``@app.cell``,
-    # so making cells depend on our sentinel doesn't get the install in
-    # before the setup block's own third-party imports run. ``await`` is
-    # also invalid at module-level Python, so we can't inject the install
-    # into the setup block's body either. Caller can detect this case via
-    # :func:`has_app_setup_block` and emit a build-time warning.
-    if has_app_setup_block(tree):
-        return source
-
     cell_nodes = [
         n
         for n in tree.body
@@ -457,17 +447,52 @@ def has_app_setup_block(source_or_tree: str | ast.Module) -> bool:
 
 
 def _find_app_assignment_index(tree: ast.Module) -> int | None:
-    """Return the index of the statement *after* ``app = marimo.App(...)``.
+    """Return the index just after ``app = marimo.App(...)``, skipping any
+    immediately-following ``with app.setup:`` block.
 
-    The bootstrap cell goes immediately after the ``app =`` line so
-    its ``@app.cell`` decorator binds to the right object. Returns
-    ``None`` when no such assignment is found (a notebook that
-    doesn't define ``app`` isn't a marimo notebook in any meaningful
-    sense, so we skip injection).
+    The bootstrap cell needs ``@app.cell`` to bind to the right
+    ``app`` object, so it must come after the assignment. It also
+    needs to come *after* any ``with app.setup:`` block — empirically,
+    inserting an ``@app.cell`` between ``app =`` and ``with app.setup:``
+    confuses marimo's runtime variable resolution and downstream cells
+    error out with ``name 'mo' is not defined``. Setup blocks are
+    nearly always immediately after ``app =`` in marimo notebooks, so
+    we just walk past them.
+
+    Returns ``None`` when no ``app = ...`` is found (not a marimo
+    notebook in any meaningful sense, so we skip injection).
     """
+    app_idx = None
     for i, node in enumerate(tree.body):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == "app":
-                    return i + 1
-    return None
+                    app_idx = i
+                    break
+            if app_idx is not None:
+                break
+    if app_idx is None:
+        return None
+
+    # Skip past any ``with app.setup:`` block(s) that follow the assignment.
+    insert_idx = app_idx + 1
+    while insert_idx < len(tree.body):
+        node = tree.body[insert_idx]
+        if not isinstance(node, ast.With):
+            break
+        is_app_setup = False
+        for item in node.items:
+            ctx = item.context_expr
+            target = ctx.func if isinstance(ctx, ast.Call) else ctx
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "app"
+                and target.attr == "setup"
+            ):
+                is_app_setup = True
+                break
+        if not is_app_setup:
+            break
+        insert_idx += 1
+    return insert_idx


### PR DESCRIPTION
## Summary

Follow-up to #40. The previous fix placed our injected bootstrap cell *between* `app = marimo.App(...)` and any `with app.setup:` block, which confused marimo's runtime variable resolution — every downstream cell in a setup-block notebook errored with \`name 'mo' is not defined\`. Fix: walk past any setup blocks immediately following the App assignment when choosing the insert position.

Also relaxed the setup-block detection in \`_maybe_stage_with_pep723\` from a hard skip-and-warn to a softer informational note. With the new insert position, the bootstrap CAN be injected for setup-block notebooks; the note tells authors that any non-bundled imports inside the setup block will still fail (since \`await\` is invalid at module-level Python) so they should be moved to a regular \`@app.cell\`.

## End-to-end on dartbrains

| Page | Mode | Before this PR | After this PR |
|---|---|---|---|
| MR_Physics.py | wasm | bootstrap injected, 0 errors | unchanged: 0 errors |
| Preprocessing.py | wasm | bootstrap injected, 0 errors | unchanged: 0 errors |
| Signal_Processing.py | wasm (uses \`with app.setup:\`) | bootstrap **skipped**, 49+ rendering errors | **bootstrap injected, 0 errors** ✅ |
| 17 static notebooks | static | 18 pre-existing errors | unchanged: same 18 |

Signal_Processing also required a small content change in dartbrains itself: \`from dartbrains_tools.notebook_utils import youtube\` was moved out of the \`with app.setup:\` block into a regular \`@app.cell\` (committed separately to dartbrains, not in this PR).

## Test plan

- [x] \`pytest -q\` 175 passing
- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] Sandbox dartbrains build: log error count goes from 90 → 0; Signal_Processing renders cleanly; bootstrap present in all 3 WASM pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)