### PR TITLE
Mount precompute slider above the cell that consumes the widget

### DIFF
--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -243,7 +243,9 @@ def _splice_precomputed_body(original_page: str, result) -> str:
     """
     marker_open = '<div class="marimo-book-buttons">'
     marker_close = "</div>"
-    body = _splice_controls_inline(result.body, result.widget_html)
+    body = _splice_controls_inline(
+        result.body, result.widget_html, anchor_cell_idx=result.splice_anchor_cell_idx
+    )
     if marker_open in original_page:
         head_end = original_page.index(marker_open)
         close_at = original_page.index(marker_close, head_end) + len(marker_close)
@@ -252,18 +254,36 @@ def _splice_precomputed_body(original_page: str, result) -> str:
     return body
 
 
-def _splice_controls_inline(body: str, widget_html: str) -> str:
-    """Insert the widget controls just before the first reactive cell.
+def _splice_controls_inline(
+    body: str, widget_html: str, *, anchor_cell_idx: int | None = None
+) -> str:
+    """Insert the widget controls inline, immediately above the cell whose
+    output the widget drives.
 
-    The body is a Markdown blob with ``<div class="marimo-book-precompute-cell"
-    data-precompute-cell="N" …>`` markers around each cell whose output
-    depends on a widget. Placing controls there keeps the slider visually
-    adjacent to the brain plot / table / chart it drives.
+    ``anchor_cell_idx`` is the source-order cell index that consumes the
+    widget (computed via AST in :func:`precompute.find_widget_consumer_cell_idx`).
+    The cell is identified in the rendered body by its
+    ``data-precompute-cell="N"`` wrapper. Mounting at this anchor — the
+    cell whose function parameters include the widget variable —
+    guarantees the slider lands immediately above the cell whose output
+    actually depends on it (the brain viewer, the figure, the table).
+
+    Falls back to the first ``data-precompute-cell`` marker when no
+    anchor was identified (rare: notebook with no reactive consumer
+    detected via AST). Falls back further to top-of-body when there are
+    no reactive markers at all.
     """
     if not widget_html:
         return body
-    needle = '<div class="marimo-book-precompute-cell"'
-    pos = body.find(needle)
+    if anchor_cell_idx is not None:
+        needle = (
+            f'<div class="marimo-book-precompute-cell" data-precompute-cell="{anchor_cell_idx}"'
+        )
+        pos = body.find(needle)
+        if pos != -1:
+            return body[:pos] + widget_html + "\n\n" + body[pos:]
+    # Fallback: first reactive cell (legacy behaviour).
+    pos = body.find('<div class="marimo-book-precompute-cell"')
     if pos == -1:
         return widget_html + "\n\n" + body
     return body[:pos] + widget_html + "\n\n" + body[pos:]

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -65,6 +65,66 @@ _STDERR_BLOCK_RE = re.compile(
 )
 
 
+def find_widget_consumer_cell_idx(source: str, widget_var_names: list[str]) -> int | None:
+    """Return the source-order cell index of the first ``@app.cell`` whose
+    parameter list includes any of ``widget_var_names``.
+
+    Marimo's data flow IS the parameter list: a cell that takes a widget
+    as a parameter is by definition a consumer of that widget. Mounting
+    the slider above the source-order-earliest consumer puts it
+    immediately above the cell whose output the slider drives — the
+    natural place a reader expects controls. This is more robust than
+    using the diff-based "first reactive cell" set, which can include
+    upstream cells whose output happens to differ across the per-value
+    re-exports (random_state, plotly trace IDs, repr addresses, …).
+
+    Counts cells in the source order produced by ``ast.parse``. Markdown
+    cells (``mo.md(...)`` calls inside ``@app.cell`` bodies) count too —
+    each ``@app.cell``-decorated function increments the index — which
+    matches the indexing that ``cells_to_markdown_segments`` and
+    ``data-precompute-cell="{idx}"`` use elsewhere in this module.
+
+    Returns ``None`` when no cell consumes any of the widgets, when the
+    source has a ``SyntaxError``, or when no ``@app.cell`` is found.
+    """
+    if not widget_var_names:
+        return None
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    targets = set(widget_var_names)
+    cell_idx = -1
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if not _is_app_cell_decorated(node):
+            continue
+        cell_idx += 1
+        params = {a.arg for a in node.args.args}
+        if params & targets:
+            return cell_idx
+    return None
+
+
+def _is_app_cell_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Whether ``node`` carries ``@app.cell`` or ``@app.cell(...)``.
+
+    Mirrors the same helper in ``transforms.pep723``; duplicated here to
+    keep this module's public surface self-contained.
+    """
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "app"
+            and target.attr == "cell"
+        ):
+            return True
+    return False
+
+
 def _diff_key(body: str) -> str:
     """Return a normalized cell body for downstream-detection comparison.
 
@@ -482,6 +542,15 @@ class PrecomputeResult:
     body: str
     widget_html: str
     reactive_cell_indices: list[int] = field(default_factory=list)
+    # Source-order cell index where the slider control panel should mount.
+    # Identified via AST (cells whose function parameters include a widget
+    # variable name). Falls back to the first reactive cell when no
+    # consumer is found in the AST (rare). Empirically far more reliable
+    # than the diff-based heuristic, which can mark upstream cells as
+    # reactive when their output is non-deterministic across re-exports
+    # (random_state, plotly trace IDs, object reprs, …) — picking such a
+    # cell as the splice anchor strands the slider above unrelated content.
+    splice_anchor_cell_idx: int | None = None
     bytes_total: int = 0
     seconds_total: float = 0.0
     skipped: bool = False
@@ -765,10 +834,22 @@ def precompute_page(
         all_widgets.extend(members)
     widget_html = _build_controls_panel_grouped(independent_groups, joint_results)
 
+    # Anchor the controls panel above the source-order-earliest cell that
+    # actually consumes any of the widgets (via parameter list = marimo
+    # data flow). Falls back to the first reactive cell if AST analysis
+    # finds no consumer (rare). See ``find_widget_consumer_cell_idx``
+    # docstring for why this is more reliable than the diff-based
+    # "first reactive cell" picker.
+    splice_anchor = find_widget_consumer_cell_idx(
+        py_path.read_text(encoding="utf-8"),
+        [c.var_name for c in all_widgets],
+    )
+
     return PrecomputeResult(
         body=body,
         widget_html=widget_html,
         reactive_cell_indices=sorted(set(cell_to_widget) | set(cell_to_group)),
+        splice_anchor_cell_idx=splice_anchor,
         bytes_total=bytes_so_far,
         seconds_total=time.monotonic() - t0,
     )

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from marimo_book.transforms.precompute import (
     WidgetCandidate,
     estimate_combinations,
+    find_widget_consumer_cell_idx,
     page_excluded,
     scan_widgets,
     substitute_widget_value,
@@ -793,3 +794,136 @@ def test_precompute_lookup_table_values_are_rendered_html(tmp_path: Path) -> Non
         assert "|---|" not in joined, (
             f"value {value_key} still contains raw markdown table delimiters"
         )
+
+
+# --- find_widget_consumer_cell_idx -----------------------------------------
+
+
+def test_consumer_cell_idx_finds_first_param_cell() -> None:
+    """Returns the source-order index of the first @app.cell with the var as a parameter."""
+    src = """import marimo
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    slider = mo.ui.slider(0, 10)
+    return (slider,)
+
+
+@app.cell
+def _(mo):
+    mo.md("intro")
+    return
+
+
+@app.cell
+def _(slider, mo):
+    return (slider.value * 2,)
+"""
+    # Cell #3 (0-indexed) is the consumer. Cells before it: imports (0),
+    # slider def (1), mo.md (2). Slider def cell doesn't TAKE slider as
+    # param, it CREATES it.
+    assert find_widget_consumer_cell_idx(src, ["slider"]) == 3
+
+
+def test_consumer_cell_idx_returns_none_when_no_consumer() -> None:
+    """Slider defined but never consumed → no anchor."""
+    src = """import marimo
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    slider = mo.ui.slider(0, 10)
+    return (slider,)
+"""
+    assert find_widget_consumer_cell_idx(src, ["slider"]) is None
+
+
+def test_consumer_cell_idx_returns_none_for_empty_widgets() -> None:
+    assert find_widget_consumer_cell_idx("import marimo\napp = marimo.App()\n", []) is None
+
+
+def test_consumer_cell_idx_handles_syntax_error() -> None:
+    """Malformed source returns None, doesn't crash the build."""
+    assert find_widget_consumer_cell_idx("def : bad\n", ["slider"]) is None
+
+
+def test_consumer_cell_idx_picks_earliest_when_multiple_consumers() -> None:
+    """Two cells consume the slider; index of the earlier one wins."""
+    src = """import marimo
+app = marimo.App()
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def _(slider):
+    a = slider.value
+    return (a,)
+
+
+@app.cell
+def _(slider):
+    b = slider.value
+    return (b,)
+"""
+    assert find_widget_consumer_cell_idx(src, ["slider"]) == 1
+
+
+def test_consumer_cell_idx_picks_earliest_across_widgets() -> None:
+    """Multiple widgets, return the earliest consumer of any."""
+    src = """import marimo
+app = marimo.App()
+
+
+@app.cell
+def _():
+    return
+
+
+@app.cell
+def _(slider2):
+    return (slider2.value,)
+
+
+@app.cell
+def _(slider1):
+    return (slider1.value,)
+"""
+    # slider2's consumer is at index 1, slider1's at index 2 → 1 wins
+    assert find_widget_consumer_cell_idx(src, ["slider1", "slider2"]) == 1
+
+
+def test_consumer_cell_idx_ignores_non_app_cell_functions() -> None:
+    """Module-level helper functions don't count as cells."""
+    src = """import marimo
+app = marimo.App()
+
+
+def helper(slider):
+    return slider.value
+
+
+@app.cell
+def _(slider):
+    return (slider.value,)
+"""
+    # `helper` isn't a cell, so the consumer is index 0 (the only cell).
+    assert find_widget_consumer_cell_idx(src, ["slider"]) == 0


### PR DESCRIPTION
## Why

The static-reactivity pipeline mounted the slider above the **first reactive cell** — defined by diffing cell output across per-value re-exports. That heuristic is fragile: any non-deterministic upstream output (sklearn \`random_state\`, plotly trace IDs, repr addresses, transient prints, library warnings, …) makes upstream cells appear \"reactive\" and the slider mounts there, leaving the actual viewer far below. Stripping stderr from the diff key only catches one source of noise; \`suppress_warnings: true\` is necessary but not sufficient.

## What changed

Replace the diff-based anchor with an AST-derived **consumer cell** anchor: the source-order-earliest \`@app.cell\` whose function parameter list contains any widget variable name. Marimo's parameter list IS the data-flow graph; a cell taking the slider as a parameter is by definition the consumer.

- New \`find_widget_consumer_cell_idx(source, widget_var_names) -> int | None\` in \`transforms/precompute.py\`.
- \`PrecomputeResult\` gains \`splice_anchor_cell_idx\` field, populated by the orchestrator.
- \`_splice_controls_inline\` in \`preprocessor.py\` mounts above the specific \`data-precompute-cell=\"{anchor_idx}\"\` div when an anchor is set; falls back to the legacy first-reactive-cell behaviour when no consumer is found in the AST.
- 7 new unit tests for the AST helper (consumer found / not found, empty widget list, syntax error, multiple consumers → earliest, multiple widgets → earliest of any, ignores non-cell helpers).

## End-to-end on dartbrains' ICA

\`component_slider\` is defined at cell index 12 (line 157 in source). The only cell taking \`component_slider\` as a parameter is at cell index 13 (line 166) — the brain-viewer + plotly subplots cell. Verified: \`find_widget_consumer_cell_idx(ica_src, ['component_slider'])\` returns 13. The slider now mounts above that specific cell, regardless of what diff-noise other cells produce.

## Test plan

- [x] \`pytest -q\` 182 passing
- [x] \`ruff check\` / \`ruff format --check\` clean
- [ ] Browser validation against the deployed dartbrains site after release lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)