### PR TITLE
Require marimo >=0.23.6 for island filename fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Require marimo ≥ 0.23.6.** That release ships
+  [marimo-team/marimo#9409](https://github.com/marimo-team/marimo/pull/9409),
+  which makes `MarimoIslandGenerator.from_file()` propagate the
+  notebook filename. On WASM pages, `__file__` and
+  `mo.notebook_dir()` now resolve to the notebook's own location
+  instead of the host's `__main__`, so relative paths like
+  `Path(__file__).parent / "data"` work without a cwd-walk
+  workaround. The corresponding caveat has been removed from the
+  WASM-mode docs.
+
 ## [0.1.17] — 2026-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workaround. The corresponding caveat has been removed from the
   WASM-mode docs.
 
+### Documentation
+
+- **Document remote data loading on WASM pages.** The WASM-mode section
+  of `building.md` now notes that DuckDB can read CSV / Parquet / JSON /
+  GeoJSON over HTTP (marimo 0.23.7) and Polars network I/O works in the
+  browser (marimo 0.23.5), so an interactive chapter can fetch its own
+  data with no backend.
+
 ## [0.1.17] — 2026-04-29
 
 ### Fixed

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -460,12 +460,6 @@ on a static page is faster end-to-end.
 - First page load is heavy (~30 MB Pyodide download, cached after).
 - Not every Python package is in Pyodide's package set — check
   [pyodide.org/packages](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
-- File system access via relative paths needs care: marimo's
-  `__file__` and `mo.notebook_dir()` resolve to internal paths under
-  `MarimoIslandGenerator`. If a notebook does
-  `Path(__file__).parent / "data"` it won't find the file. Use a
-  cwd-walk pattern instead, or wait for
-  [marimo-team/marimo#9391](https://github.com/marimo-team/marimo/issues/9391).
 
 The `Authoring → WASM demo` page in this book is a working example.
 

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -461,6 +461,14 @@ on a static page is faster end-to-end.
 - Not every Python package is in Pyodide's package set — check
   [pyodide.org/packages](https://pyodide.org/en/stable/usage/packages-in-pyodide.html).
 
+**Loading remote data.** WASM pages can pull datasets over HTTP with no
+server of their own. As of marimo 0.23.7, DuckDB reads CSV / Parquet /
+JSON / GeoJSON from a URL inside `mo.sql`, SQL cells, and the
+`duckdb.read_*` Python API — e.g.
+`SELECT * FROM read_csv('https://example.com/cars.csv')`. Polars network
+I/O (`pl.read_csv(url)` and friends) also works in WASM as of 0.23.5. So
+a fully interactive chapter can load its own data with zero backend.
+
 The `Authoring → WASM demo` page in this book is a working example.
 
 ## ePub / other formats?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "lxml>=5.0",
     "pybtex>=0.24",
-    "marimo>=0.23,<0.24",
+    # 0.23.6 ships marimo-team/marimo#9409, which makes
+    # `MarimoIslandGenerator.from_file()` propagate the notebook
+    # filename so `__file__` / `mo.notebook_dir()` resolve correctly on
+    # WASM pages (was: resolved to the host's `__main__`).
+    "marimo>=0.23.6,<0.24",
     # marimo declares nbformat as an optional extra; we always use
     # `marimo export ipynb` under the hood, so pin it as a hard dep.
     "nbformat>=5.0",


### PR DESCRIPTION
## What

marimo **0.23.6** (released 2026-05-11) ships [marimo-team/marimo#9409](https://github.com/marimo-team/marimo/pull/9409), our upstream fix that makes `MarimoIslandGenerator.from_file()` propagate the notebook filename. It closes [#9391](https://github.com/marimo-team/marimo/issues/9391).

Before the fix, on WASM pages `__file__` and `mo.notebook_dir()` resolved to the host's `__main__` instead of the notebook source, so relative paths like `Path(__file__).parent / "data"` silently failed. `marimo-book` calls `MarimoIslandGenerator.from_file()` directly (`src/marimo_book/transforms/wasm.py`), so it benefits directly.

This PR incorporates that release downstream.

## Changes

- **`pyproject.toml`** — bump `marimo>=0.23,<0.24` → `marimo>=0.23.6,<0.24` (pin now guarantees the fix).
- **`docs/content/building.md`** — remove the WASM-mode filesystem caveat that told users to use a cwd-walk workaround "or wait for marimo-team/marimo#9391." The pin makes it moot.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

No workflow changes needed — nothing in `.github/workflows/` pins marimo separately.

## Verification

- `ruff check` + `ruff format --check` clean
- `pytest -q` → 188 passed
- Docs build clean for these changes (the only strict-mode warnings locally are the `social` plugin's system cairo/pango deps, which CI provides via apt)
- Installed marimo locally is 0.23.8, satisfies the new pin

## Follow-up (separate, not in this PR)

The downstream **dartbrains** cleanup — dropping the `_find_root()` cwd-walk workaround in `content/Preprocessing.py` — is deliberately sequenced after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)