### PR TITLE
Date CHANGELOG for 0.1.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.18] — 2026-06-03
 
 ### Fixed
 


### PR DESCRIPTION
Dates the `[Unreleased]` section as **0.1.18 — 2026-06-03** to cut the patch release.

Contents of 0.1.18 (both already merged to main):
- **#45** — require marimo ≥ 0.23.6 (the `MarimoIslandGenerator.from_file` filename fix, marimo-team/marimo#9409) + WASM remote-data-loading docs.
- **#46** — stage PEP 723 / precompute copies as sibling *files* so `Path(__file__).resolve().parent.parent` resolves to the book root on WASM pages (fixes the staging off-by-one that defeated #9409 downstream).

After merge: publish the `v0.1.18` release from the release-drafter draft to ship the wheel to PyPI. This unblocks the dartbrains `_find_root()` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)