### PR TITLE
docs: document the real tag-push release flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,20 +50,41 @@ than waiting for auto-reload.
 Releases are tag-driven via `hatch-vcs`. There is **no `version` field
 in `pyproject.toml`** — the version is the latest `v*` git tag.
 
+`.github/workflows/publish.yml` triggers on **`push: tags: ["v*"]`**
+(not on publishing a GitHub Release). So the act that ships a release
+is **pushing a `v*` tag**; `hatch-vcs` reads the tag, builds a wheel
+versioned exactly to it (e.g. `v0.1.18` → `0.1.18`), and ships it to
+PyPI via OIDC Trusted Publisher.
+
 To cut a release:
 
 1. Open a tiny PR that dates the `[Unreleased]` section in
-   `CHANGELOG.md` to today (one-line change). Merge it.
-2. Go to <https://github.com/ljchang/marimo-book/releases>. The
-   `release-drafter` bot has been maintaining a draft populated with
-   bullets from every merged PR. Edit if needed, set the tag (e.g.
-   `v0.1.0a3`), and click **Publish release**.
-3. The `v*` tag fires `.github/workflows/publish.yml`. `hatch-vcs` reads
-   the tag, builds a wheel versioned exactly `0.1.0a3`, ships it to
-   PyPI via OIDC Trusted Publisher.
+   `CHANGELOG.md` to today (one-line change, e.g.
+   `## [0.1.18] — YYYY-MM-DD`). Merge it.
+2. Tag merged `main` at that commit and push the tag:
 
-That's it. **Never push version edits directly to main.** The version
-lives in exactly one place: the git tag.
+   ```bash
+   git checkout main && git pull
+   git tag -a v0.1.18 -m "Release 0.1.18"
+   git push origin v0.1.18
+   ```
+
+   The pushed tag fires `publish.yml` → PyPI. Watch the run:
+   `gh run watch --repo ljchang/marimo-book` (or the Actions tab).
+
+That's it. **Never push version edits directly to main**, and never
+push a `v*` tag you don't intend to publish — the tag *is* the
+release trigger. The version lives in exactly one place: the git tag.
+
+**Note (2026-06): the `release-drafter` GitHub-Release draft is stale**
+(stuck at `v0.1.11`) and is **not** part of the live flow — releases
+`v0.1.12`–`v0.1.17` were cut by direct tag push and have no GitHub
+Release object at all. Don't rely on "publish the draft"; push the tag.
+If you want GitHub Release notes too, run
+`gh release create v0.1.18 --generate-notes` *instead of* the manual
+`git push origin v0.1.18` (creating a release also creates+pushes the
+tag, which fires `publish.yml` the same way) — but the tag push is the
+only thing that actually publishes to PyPI.
 
 See `PUBLISHING.md` for full detail (one-time PyPI setup, label
 conventions for release-drafter categorisation, yanking, etc.).

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,18 +6,33 @@ token needed once the one-time setup is done.
 
 ## How releases work (the short version)
 
+`publish.yml` triggers on **`push: tags: ["v*"]`** — pushing a `v*` tag
+is what publishes a release.
+
 1. Open a tiny PR that dates the `[Unreleased]` section in
    `CHANGELOG.md` to today (one-line change). Merge it.
-2. Go to <https://github.com/ljchang/marimo-book/releases>. The
-   `release-drafter` bot has been maintaining a draft populated with
-   bullets from every merged PR. Edit if needed, set the tag to
-   `v0.1.0a3` (or whatever the next version is), and click **Publish
-   release**.
-3. The `v*` tag fires `publish.yml`. `hatch-vcs` reads the tag, builds
-   a wheel versioned `0.1.0a3`, ships it to PyPI via OIDC.
+2. Tag merged `main` and push the tag:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a v0.1.18 -m "Release 0.1.18"   # next version
+   git push origin v0.1.18
+   ```
+
+3. The pushed `v*` tag fires `publish.yml`. `hatch-vcs` reads the tag,
+   builds a wheel versioned exactly to it (`v0.1.18` → `0.1.18`), ships
+   it to PyPI via OIDC.
 
 That's it. **No `pyproject.toml` edit, no `__init__.py` edit, no direct
 push to main.** The version is the tag.
+
+> **The `release-drafter` GitHub-Release draft is stale** (stuck at
+> `v0.1.11`) and is *not* part of the live flow — `v0.1.12`–`v0.1.17`
+> were cut by direct tag push and have no GitHub Release object. Push
+> the tag; don't "publish the draft." If you also want GitHub Release
+> notes, use `gh release create v0.1.18 --generate-notes` (it
+> creates+pushes the tag, firing `publish.yml` the same way) instead of
+> the bare `git push origin v0.1.18`.
 
 ## One-time setup
 
@@ -98,6 +113,14 @@ Untagged dev commits get versions like `0.1.0a3.dev5+gabc1234.d20260425`
 makes pre-release wheels distinguishable without needing a manual bump.
 
 ## Release-drafter
+
+> **Currently stale / out of the live flow.** The draft is stuck at
+> `v0.1.11`; recent releases were cut by direct tag push (see "How
+> releases work") and have no GitHub Release object. The label table
+> below still documents how categorisation *would* work if the draft is
+> revived, but publishing a release today does **not** go through it —
+> the tag push is what ships to PyPI. The `CHANGELOG.md` is the
+> authoritative, hand-maintained release notes.
 
 `.github/workflows/release-drafter.yml` runs on every merged PR and
 keeps a draft Release on github.com up to date. It groups entries by


### PR DESCRIPTION
While cutting 0.1.18 I found the documented release flow doesn't match reality.

**Documented (stale):** date the CHANGELOG → go to the Releases page → publish the `release-drafter` draft → its `v*` tag fires `publish.yml`.

**Actual:** `publish.yml` triggers on **`push: tags: ["v*"]`**. The `release-drafter` draft is stuck at `v0.1.11` and has been bypassed — `v0.1.12`–`v0.1.17` were cut by **direct tag push** and have **no GitHub Release object** at all (`gh release view v0.1.17` → "release not found"), yet they're on PyPI. So the thing that actually ships a release is pushing the tag.

This corrects the release-flow sections in **CLAUDE.md** and **PUBLISHING.md** to:
- describe the tag-push mechanism (`git tag -a v0.1.18 … && git push origin v0.1.18`),
- flag the stale release-drafter draft and note CHANGELOG.md is the authoritative release notes,
- mention `gh release create --generate-notes` as the option if you also want GitHub Release notes (it creates+pushes the tag, firing the same workflow).

Docs-only. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)