### PR TITLE
Date CHANGELOG [Unreleased] as 0.1.19 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.19] — 2026-06-05
 
 ### Added
 


### PR DESCRIPTION
Dates the `[Unreleased]` CHANGELOG section to `## [0.1.19] — 2026-06-05` ahead of cutting the `v0.1.19` tag.

This release ships the **blog / news module** (#50) and the **auto-generated API reference** `api_docs` (#51), plus the blog review bug-fixes.

Per the repo's tag-driven release flow: merge this, then push the `v0.1.19` tag to publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)