### PR TITLE
fix(api): dotted package names + count API pages in build report

### DIFF
--- a/src/marimo_book/api_docs.py
+++ b/src/marimo_book/api_docs.py
@@ -104,6 +104,17 @@ def _build_module(
     return {key: page_rel}
 
 
+def count_pages(nav: object) -> int:
+    """Count staged ``.md`` pages referenced in a nav subtree."""
+    if isinstance(nav, str):
+        return 1 if nav.endswith(".md") else 0
+    if isinstance(nav, dict):
+        return sum(count_pages(v) for v in nav.values())
+    if isinstance(nav, list):
+        return sum(count_pages(v) for v in nav)
+    return 0
+
+
 def _write_page(path: Path, title: str, dotted: str) -> None:
     """Write a minimal ``::: dotted`` directive page."""
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/marimo_book/api_docs.py
+++ b/src/marimo_book/api_docs.py
@@ -54,7 +54,13 @@ def stage_api_docs(cfg: ApiDocs, *, search_paths: list[Path], docs_dir: Path) ->
                 f"{exc.__class__.__name__}: {exc}"
             ) from exc
         section.append(
-            _build_module(module, cfg, docs_dir=docs_dir, rel_prefix=f"{cfg.dir}/{name}")
+            _build_module(
+                module,
+                cfg,
+                docs_dir=docs_dir,
+                rel_prefix=f"{cfg.dir}/{name.replace('.', '/')}",
+                label=name,
+            )
         )
     return [{cfg.title: section}]
 
@@ -71,12 +77,19 @@ def _public_children(module: Module, cfg: ApiDocs) -> list[Module]:
     return out
 
 
-def _build_module(module: Module, cfg: ApiDocs, *, docs_dir: Path, rel_prefix: str) -> dict:
+def _build_module(
+    module: Module, cfg: ApiDocs, *, docs_dir: Path, rel_prefix: str, label: str | None = None
+) -> dict:
     """Stage a page for ``module`` and return its nav entry.
 
     A module with public submodules becomes a package node: an ``index.md``
     plus one child entry each. A leaf module becomes a single ``<name>.md``.
+
+    ``label`` overrides the nav key (used for dotted top-level package names so
+    the full dotted name labels the section); it defaults to ``module.name`` so
+    nested children keep their short-name keys.
     """
+    key = label or module.name
     children = _public_children(module, cfg)
     if children:
         page_rel = f"{rel_prefix}/index.md"
@@ -85,10 +98,10 @@ def _build_module(module: Module, cfg: ApiDocs, *, docs_dir: Path, rel_prefix: s
             _build_module(c, cfg, docs_dir=docs_dir, rel_prefix=f"{rel_prefix}/{c.name}")
             for c in children
         ]
-        return {module.name: [page_rel, *child_nav]}
+        return {key: [page_rel, *child_nav]}
     page_rel = f"{rel_prefix}.md"
     _write_page(docs_dir / page_rel, module.name, module.path)
-    return {module.name: page_rel}
+    return {key: page_rel}
 
 
 def _write_page(path: Path, title: str, dotted: str) -> None:

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import yaml
 
-from .api_docs import resolve_search_paths, stage_api_docs
+from .api_docs import count_pages, resolve_search_paths, stage_api_docs
 from .blog import (
     author_id,
     build_author_roster,
@@ -540,7 +540,9 @@ class Preprocessor:
         if self.book.api_docs.enabled:
             resolved = resolve_search_paths(self.book.api_docs, self.book_dir)
             api_paths = [str(p) for p in resolved]
-            nav.extend(stage_api_docs(self.book.api_docs, search_paths=resolved, docs_dir=docs_dir))
+            api_nav = stage_api_docs(self.book.api_docs, search_paths=resolved, docs_dir=docs_dir)
+            nav.extend(api_nav)
+            report.pages += count_pages(api_nav)
 
         emit_mkdocs_yml(
             self.book,

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -123,6 +123,41 @@ def test_dotted_package_name_maps_to_path_and_keeps_full_label(tmp_path):
     assert section[0]["sample_pkg.sub"][0] == "api/sample_pkg/sub/index.md"
 
 
+def test_count_pages_counts_md_leaves(tmp_path):
+    from marimo_book.api_docs import count_pages
+
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    cfg = ApiDocs(enabled=True, packages=["sample_pkg"])
+    nav = stage_api_docs(cfg, search_paths=[FIXTURES], docs_dir=docs_dir)
+    # sample_pkg: index + core + sub/index + sub/widgets == 4 pages
+    assert count_pages(nav) == 4
+
+
+def test_preprocessor_counts_api_pages_in_report(tmp_path):
+    book_dir = tmp_path / "book"
+    (book_dir / "content").mkdir(parents=True)
+    (book_dir / "content" / "intro.md").write_text("# Intro\n", encoding="utf-8")
+
+    book = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [{"file": "content/intro.md"}],
+            "api_docs": {
+                "enabled": True,
+                "packages": ["sample_pkg"],
+                "paths": [str(FIXTURES)],
+            },
+        }
+    )
+
+    out_dir = tmp_path / "_site_src"
+    pre = Preprocessor(book, book_dir=book_dir)
+    report = pre.build(out_dir=out_dir)
+    # 1 intro page + 4 API pages (index + core + sub/index + sub/widgets).
+    assert report.pages >= 1 + 4
+
+
 def _book_with_api(**api_kwargs):
     return Book(
         title="T",

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -107,6 +107,22 @@ def test_subpackage_with_all_children_excluded_collapses_to_leaf(tmp_path):
     ]
 
 
+def test_dotted_package_name_maps_to_path_and_keeps_full_label(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    cfg = ApiDocs(enabled=True, packages=["sample_pkg.sub"])
+    nav = stage_api_docs(cfg, search_paths=[FIXTURES], docs_dir=docs_dir)
+
+    # Directory layout uses path segments, not a literal dotted dir.
+    assert (docs_dir / "api/sample_pkg/sub/index.md").exists()
+    assert (docs_dir / "api/sample_pkg/sub/widgets.md").exists()
+    assert not (docs_dir / "api/sample_pkg.sub").exists()
+    # Top-level nav key is the FULL dotted name (prevents same-last-segment collisions).
+    section = nav[0]["API Reference"]
+    assert list(section[0].keys()) == ["sample_pkg.sub"]
+    assert section[0]["sample_pkg.sub"][0] == "api/sample_pkg/sub/index.md"
+
+
 def _book_with_api(**api_kwargs):
     return Book(
         title="T",


### PR DESCRIPTION
Two follow-up fixes from the `api_docs` code review (deferred from #51):

- **Dotted package names** — `packages: ['a.b']` now stages into `api/a/b/…` (path segments, not a literal-dotted `api/a.b/` dir) and labels the nav section with the **full dotted name**, so packages sharing a last segment (e.g. `org_a.utils` + `org_b.utils`) no longer collide on the nav key. Plain top-level names are byte-for-byte unchanged.
- **Page count** — staged API pages are now counted in `BuildReport.pages` (a new `count_pages` helper), so the build summary no longer undercounts when `api_docs` is enabled — consistent with how blog/changelog pages are counted.

The third deferred item — sweeping stale `api/` pages between builds — is **working as designed**: in-place staging deliberately leaves stale files for `marimo-book serve` livereload mtime correctness, and `marimo-book clean` / `build --clean` wipe them (same as removed-TOC pages). No code change.

## Test Plan
- [x] `pytest -q` → 243 passed
- [x] New tests: dotted-name layout + full-dotted nav key; `count_pages` unit; preprocessor `report.pages` includes API pages
- [x] Pre-existing api_docs tests unchanged + green
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)