### PR TITLE
fix(css): left-align the sidebar logo

### DIFF
--- a/src/marimo_book/assets/logo_sidebar.css
+++ b/src/marimo_book/assets/logo_sidebar.css
@@ -27,8 +27,12 @@
   .md-sidebar--primary .md-nav--primary > .md-nav__title {
     display: flex;
     align-items: center;
-    justify-content: center;
-    padding: 1rem 0.6rem 0.75rem 0.6rem;
+    /* Left-align the logo: the header site-title and all nav items are
+     * left-aligned, so a centered logo reads as shoved to the right. The
+     * left padding matches Material's nav-link text inset so the logo's
+     * left edge lines up with the chapter list below it. */
+    justify-content: flex-start;
+    padding: 1rem 0.6rem 0.75rem 0.75rem;
     height: auto;
     background-color: var(--md-default-bg-color);
     box-shadow: none;


### PR DESCRIPTION
The `logo_placement: sidebar` logo was centered in the nav title container, but the header site-title and every nav item are left-aligned — so the centered logo read as **shoved to the right**.

Left-align it (`justify-content: flex-start`) with a left padding matching Material's nav-link text inset, so the logo's left edge lines up with the chapter list and the header title.

Verified in-browser (Playwright): logo left edge within ~3px of the nav text at both 1440px and 1920px (was ~55px off-center before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)