### PR TITLE
fix(api): skip import-alias members in the api_docs submodule walk

### DIFF
--- a/src/marimo_book/api_docs.py
+++ b/src/marimo_book/api_docs.py
@@ -66,10 +66,18 @@ def stage_api_docs(cfg: ApiDocs, *, search_paths: list[Path], docs_dir: Path) ->
 
 
 def _public_children(module: Module, cfg: ApiDocs) -> list[Module]:
-    """Submodules that get their own page: non-underscore, not excluded."""
+    """Submodules that get their own page: non-underscore, not excluded.
+
+    Skips Griffe *alias* members — these are ``import pkg`` references (e.g.
+    ``feat.utils.io`` doing ``import feat``), not submodules owned by this
+    package. Following them recurses back into the imported package, an
+    infinite cycle when the import targets an ancestor.
+    """
     out: list[Module] = []
     for child_name, child in sorted(module.modules.items()):
         if child_name.startswith("_"):
+            continue
+        if child.is_alias:
             continue
         if any(fnmatch.fnmatch(child.path, pat) for pat in cfg.exclude):
             continue

--- a/tests/fixtures/alias_cycle_pkg/__init__.py
+++ b/tests/fixtures/alias_cycle_pkg/__init__.py
@@ -1,0 +1,6 @@
+"""Package whose submodule imports the package itself (alias-cycle regression).
+
+Mirrors py-feat's ``feat.utils.io`` doing ``import feat``: Griffe surfaces the
+import as a resolvable *alias* module member, which naive submodule recursion
+would follow back into the package — an infinite cycle.
+"""

--- a/tests/fixtures/alias_cycle_pkg/leaf.py
+++ b/tests/fixtures/alias_cycle_pkg/leaf.py
@@ -1,0 +1,8 @@
+"""A submodule that imports its own top-level package by name."""
+
+import alias_cycle_pkg  # noqa: F401
+
+
+def thing() -> str:
+    """Return a thing."""
+    return "thing"

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -301,3 +301,34 @@ def test_preprocessor_stages_api_section(tmp_path):
     plugin = next(p for p in mkdocs["plugins"] if isinstance(p, dict) and "mkdocstrings" in p)
     paths = plugin["mkdocstrings"]["handlers"]["python"]["paths"]
     assert all(Path(p).is_absolute() for p in paths)
+
+
+def test_imported_ancestor_module_is_not_followed(tmp_path):
+    """A submodule that does ``import <root_pkg>`` must not be walked.
+
+    Griffe surfaces such an import as a resolvable *alias* module member.
+    Following it recurses back through the package forever (regression seen
+    with py-feat's ``feat.utils.io`` doing ``import feat``). The alias must be
+    skipped, leaving the importing module a normal leaf page.
+    """
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    cfg = ApiDocs(enabled=True, packages=["alias_cycle_pkg"])
+
+    nav = stage_api_docs(cfg, search_paths=[FIXTURES], docs_dir=docs_dir)
+
+    # leaf stays a leaf page; the `import alias_cycle_pkg` alias is ignored
+    assert (docs_dir / "api/alias_cycle_pkg/leaf.md").exists()
+    assert not (docs_dir / "api/alias_cycle_pkg/leaf").is_dir()
+    assert nav == [
+        {
+            "API Reference": [
+                {
+                    "alias_cycle_pkg": [
+                        "api/alias_cycle_pkg/index.md",
+                        {"leaf": "api/alias_cycle_pkg/leaf.md"},
+                    ]
+                }
+            ]
+        }
+    ]


### PR DESCRIPTION
## Summary

`api_docs`'s `_public_children` recursed into Griffe **alias** members — `import pkg` references such as `feat.utils.io` doing `import feat` — following them back into the imported package. When the import targets an ancestor this is an **infinite cycle**, blowing up the build with `OSError: File name too long` (path like `feat/utils/io/feat/utils/io/…`). This would hit py-feat itself.

Fix: skip `child.is_alias` members; only package-owned filesystem submodules get their own page. Re-exported filesystem submodules (`from . import data`) still appear as real (non-alias) modules, so they're unaffected. This also resolves the cross-package-alias-leak concern raised in the original api_docs review (an aliased module from another package would have produced a `::: otherpkg._impl` page).

Authored on `main` locally; moved to this branch since direct main pushes are blocked.

## Test Plan
- [x] New regression test `test_imported_ancestor_module_is_not_followed` + `alias_cycle_pkg` fixture (a submodule importing its own top-level package)
- [x] `pytest -q` → 244 passed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)