### PR TITLE
fix: nested-nav alignment, visible clicked links, drop generator notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Nested API package nav alignment (for real this time).** 0.1.22's fix was
+  ineffective — its selector had lower specificity than the leaf-indent rule,
+  so a collapsible package label (e.g. `feat.utils`) still rendered indented
+  *further* than its own children. The override now outspecifies the leaf rule.
+- **Links no longer disappear when clicked.** Footer and content links lacked
+  explicit `focus`/`active`/`visited` colors, so a clicked link could render
+  with a near-invisible color. All interactive states are now pinned visible.
+
+### Changed
+
+- Drop Material's "Made with Material for MkDocs" footer notice
+  (`extra.generator: false`); the "Made with Marimo-Book" credit remains.
+
 ## [0.1.22] — 2026-06-08
 
 ### Added

--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -110,8 +110,10 @@
 /* A collapsible item (e.g. an API package like `feat.utils`) wraps its link in
    a `.md-nav__container` that already carries the leaf indent; the inner link
    must not add it again, or the parent label ends up indented *further* than
-   its own nested children. Zero the inner padding so the container's wins. */
-.md-nav--primary .md-nav__container > .md-nav__link {
+   its own nested children. Zero the inner padding so only the container's
+   indent applies. The selector mirrors the leaf-indent rule above plus
+   `.md-nav__container` (6 classes) so it outspecifies it and actually wins. */
+.md-nav--primary .md-nav__item--section .md-nav__list .md-nav__item .md-nav__container > .md-nav__link {
   padding-left: 0;
 }
 
@@ -207,9 +209,25 @@
   text-decoration-color: var(--md-default-fg-color--lighter);
   transition: color 0.12s, text-decoration-color 0.12s;
 }
-.md-typeset a:not(.md-button):not(.headerlink):hover {
+.md-typeset a:not(.md-button):not(.headerlink):hover,
+.md-typeset a:not(.md-button):not(.headerlink):focus,
+.md-typeset a:not(.md-button):not(.headerlink):active {
   color: var(--md-primary-fg-color);
   text-decoration-color: var(--md-primary-fg-color);
+}
+/* Pin every interactive state to a visible color. Without explicit
+   focus/active/visited rules a *clicked* link could briefly render with an
+   unset/near-invisible color (Material's base accent handling), so the text
+   vanished on click. */
+.md-typeset a:not(.md-button):not(.headerlink):visited {
+  color: var(--md-default-fg-color);
+}
+.md-footer-meta.md-typeset a:focus,
+.md-footer-meta.md-typeset a:visited {
+  color: var(--md-default-fg-color--light);
+}
+.md-footer-meta.md-typeset a:active {
+  color: var(--md-primary-fg-color);
 }
 
 /* --- Code: sharp corners, hairline border (not chunky) ------------------- */

--- a/src/marimo_book/shell.py
+++ b/src/marimo_book/shell.py
@@ -88,6 +88,9 @@ def _build_config(
         'Made with <a href="https://marimobook.org" target="_blank" rel="noopener">Marimo-Book</a>'
     )
     cfg["copyright"] = f"{book.copyright} · {_attribution}" if book.copyright else _attribution
+    # Drop Material's "Made with Material for MkDocs" footer notice — the
+    # Marimo-Book credit in `copyright` above is the attribution we keep.
+    cfg.setdefault("extra", {})["generator"] = False
 
     cfg["theme"] = _theme_block(book)
     base_css = ["stylesheets/extra.css"]


### PR DESCRIPTION
Three docs-polish fixes surfaced while dogfooding on py-feat (all in `[Unreleased]`):

### Fixed
- **Nested API package nav alignment.** The 0.1.22 fix was ineffective — its selector (`.md-nav__container > .md-nav__link`, 3 classes) had *lower* specificity than the leaf-indent rule (`.md-nav__item--section .md-nav__list .md-nav__item .md-nav__link`, 5 classes), so a collapsible package label like `feat.utils` still double-padded and sat indented further than its own submodules. Override now outspecifies the leaf rule. Verified in-browser: `feat.utils` text-left 112px → 94px (flush with `feat.detector`), submodules nest at 106px.
- **Links no longer vanish when clicked.** Footer + content links had no explicit `focus`/`active`/`visited` colors, so a clicked link could render near-invisible. All interactive states pinned to visible colors.

### Changed
- Drop Material's "Made with Material for MkDocs" footer notice (`extra.generator: false`); the "Made with Marimo-Book" credit stays.

CI gate: ruff 0.15.16 format + check pass; full suite green locally.