### PR TITLE
fix(sync-releases): demote all release-body headings (not just H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.25] — 2026-06-15
+
+### Fixed
+
+- **`sync-releases` changelog heading levels.** Each release renders under a
+  `## <version>` heading, but a release note's own headings (e.g. an
+  `## Installation` section) were embedded verbatim and collided with the page
+  structure. The body's headings are now demoted by two levels (H1→H3, H2→H4,
+  …, capped at H6) so they nest under the version heading. Previously only `#`
+  (H1) was demoted.
+
 ## [0.1.24] — 2026-06-14
 
 ### Added

--- a/src/marimo_book/release_notes.py
+++ b/src/marimo_book/release_notes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.error
 import urllib.request
 
@@ -128,19 +129,23 @@ def render_changelog_markdown(
             # Normalise CRLF from the API and demote any H1 in the body so it
             # doesn't compete with the per-release H2 heading.
             body = body.replace("\r\n", "\n")
-            lines.extend(_demote_h1(body).split("\n"))
+            lines.extend(_demote_headings(body).split("\n"))
             lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _demote_h1(markdown: str) -> str:
-    """Demote top-level ``# `` headings in a release body to ``### ``.
+_ATX_HEADING = re.compile(r"(#{1,6})\s")
 
-    Release bodies occasionally open with their own ``# Title``; left as-is
-    that would render as a page-level H1 mid-page. Shift only leading-``#``
-    lines (not ``##`` etc.) down two levels. Fenced code blocks are left
-    untouched.
+
+def _demote_headings(markdown: str, by: int = 2) -> str:
+    """Demote every ATX heading in a release body by ``by`` levels.
+
+    Each release renders under a ``## <version>`` heading, so the body's own
+    headings must sit *below* H2 or they collide with the page structure — e.g.
+    a release note's ``## Installation`` would otherwise render at the same
+    level as the version. Shift all headings down (H1→H3, H2→H4, …), capped at
+    H6. Fenced code blocks are left untouched.
     """
     out: list[str] = []
     in_fence = False
@@ -150,8 +155,10 @@ def _demote_h1(markdown: str) -> str:
             in_fence = not in_fence
             out.append(line)
             continue
-        if not in_fence and stripped.startswith("# "):
-            out.append("### " + stripped[2:])
+        m = None if in_fence else _ATX_HEADING.match(stripped)
+        if m:
+            level = min(len(m.group(1)) + by, 6)
+            out.append("#" * level + stripped[m.end(1) :])
         else:
             out.append(line)
     return "\n".join(out)

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 import marimo_book.release_notes as rn
 from marimo_book.cli import app
 from marimo_book.config import Book, ReleaseNotes
-from marimo_book.release_notes import _demote_h1, render_changelog_markdown
+from marimo_book.release_notes import _demote_headings, render_changelog_markdown
 
 RELEASES = [
     {
@@ -75,12 +75,14 @@ def test_render_empty_releases():
     assert "github.com/o/r/releases" in md
 
 
-def test_demote_h1_leaves_fenced_code_alone():
-    src = "# Title\n\n```\n# not a heading\n```\n## sub"
-    out = _demote_h1(src)
-    assert out.startswith("### Title")
-    assert "# not a heading" in out  # inside fence, untouched
-    assert "## sub" in out  # H2 untouched
+def test_demote_headings_shifts_all_levels_and_skips_fences():
+    src = "# Title\n\n```\n# not a heading\n```\n## sub\n### deep\n###### capped"
+    lines = _demote_headings(src).split("\n")
+    assert "### Title" in lines  # H1 -> H3
+    assert "#### sub" in lines  # H2 -> H4
+    assert "##### deep" in lines  # H3 -> H5
+    assert "###### capped" in lines  # H6 + 2 clamped to H6
+    assert "# not a heading" in lines  # inside fence, untouched (exact line)
 
 
 # --- config ------------------------------------------------------------------


### PR DESCRIPTION
Each release in a generated changelog renders under a `## <version>` heading, but a release note's own headings (e.g. `## Installation`) were embedded verbatim and collided with the page structure (duplicate same-level headings). Generalize `_demote_h1` → `_demote_headings`: shift every ATX heading down two levels (H1→H3, H2→H4, …, capped at H6) so body headings nest under the version heading; fenced code untouched. Full suite (291) + ruff lint/format green. Finalizes 0.1.25.