### PR TITLE
fix(render): decouple committed-render cache key from package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Cached renders no longer invalidate on every release.** The committed
+  `_rendered/` body signature embedded the full marimo-book package version, so
+  *any* release — even one that can't change a notebook's output (CLI, nav CSS,
+  `sync-releases`) — marked every cached page stale. A plain `marimo-book build`
+  then fell back to *executing* the notebooks; on a deploy runner without the
+  notebooks' real dependencies that published tracebacks instead of the docs.
+  The signature now keys on a hand-bumped `_RENDER_OUTPUT_VERSION` contract,
+  bumped only when the export output itself changes. Upgrading marimo-book no
+  longer forces a re-render (and re-execution of heavy notebooks) unless the
+  render output actually changed.
+
 ## [0.1.25] — 2026-06-15
 
 ### Fixed

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -246,6 +246,18 @@ def _book_signature(book: Book) -> str:
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+# Bump ONLY when a marimo-book change actually alters a notebook's *rendered
+# body* bytes (the export pipeline / cell HTML structure). This is the
+# render-output contract version, deliberately decoupled from the package
+# version: a release that only touches unrelated surfaces (CLI, nav CSS,
+# sync-releases, the button row) must NOT invalidate every committed
+# ``_rendered/`` body and force a costly re-execution of heavy notebooks.
+# Using the package version here (the old behavior) nuked the cache on every
+# release, so a patch bump silently re-executed GPU/video notebooks in CI —
+# which, on a deploy runner without the notebooks' deps, published tracebacks.
+_RENDER_OUTPUT_VERSION = "1"
+
+
 def _render_body_signature(book: Book) -> str:
     """Hash the fields that change a notebook's *rendered body*.
 
@@ -254,15 +266,16 @@ def _render_body_signature(book: Book) -> str:
     / ``repo`` / ``branch`` / the TOC. It DOES depend on ``defaults``
     (e.g. ``hide_first_code_cell``, ``suppress_warnings``), ``dependencies``
     (which mutate the executed source), ``widget_defaults`` (anywidget seed
-    state), and the marimo-book version (export output can change across
-    releases). Stored with each ``RenderedStore`` entry so a build can tell a
-    committed body is stale even when the source bytes are unchanged.
+    state), and :data:`_RENDER_OUTPUT_VERSION` — a hand-bumped contract version
+    that changes only when the export output itself changes, NOT on every
+    package release. Stored with each ``RenderedStore`` entry so a build can
+    tell a committed body is stale even when the source bytes are unchanged.
     """
     relevant: dict = {
         "defaults": book.defaults.model_dump(mode="json"),
         "dependencies": book.dependencies.model_dump(mode="json"),
         "widget_defaults": book.widget_defaults,
-        "marimo_book_version": _resolve_tool_version(),
+        "render_output_version": _RENDER_OUTPUT_VERSION,
     }
     payload = json.dumps(relevant, sort_keys=True, default=str)
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/test_cached_render.py
+++ b/tests/test_cached_render.py
@@ -234,6 +234,35 @@ def test_build_cached_stale_when_render_config_changes(tmp_path: Path) -> None:
     m.assert_called()  # stale → fell back to a live render
 
 
+def test_render_body_sig_ignores_package_version(tmp_path: Path) -> None:
+    """A package-version bump alone must NOT invalidate committed bodies.
+
+    Regression guard: the render signature used to embed the full package
+    version, so any release (even one that can't change export output) went
+    stale and forced a re-execution of every cached notebook. It now keys on
+    a hand-bumped render-output contract version instead.
+    """
+    from marimo_book.preprocessor import _render_body_signature
+
+    book = _book_with_cached_nb(tmp_path)
+    with patch("marimo_book.preprocessor._resolve_tool_version", return_value="0.1.24"):
+        sig_a = _render_body_signature(book)
+    with patch("marimo_book.preprocessor._resolve_tool_version", return_value="9.9.9"):
+        sig_b = _render_body_signature(book)
+    assert sig_a == sig_b
+
+
+def test_render_body_sig_changes_with_render_output_version(tmp_path: Path) -> None:
+    """Bumping the render-output contract version DOES invalidate bodies."""
+    from marimo_book.preprocessor import _render_body_signature
+
+    book = _book_with_cached_nb(tmp_path)
+    sig_a = _render_body_signature(book)
+    with patch("marimo_book.preprocessor._RENDER_OUTPUT_VERSION", "999"):
+        sig_b = _render_body_signature(book)
+    assert sig_a != sig_b
+
+
 # --- strict gate: a stale cached page must fail CI, not silently execute -----
 
 


### PR DESCRIPTION
## Problem

The committed `_rendered/` body signature (`_render_body_signature`) embedded
the full marimo-book **package version**. So *any* release — even one that
cannot change a notebook's rendered output (CLI, nav CSS, `sync-releases`) —
flipped every cached page to "stale". A plain `marimo-book build` then falls
back to **executing** the notebooks; on a deploy runner that installs only
marimo-book (no torch/feat), that publishes `ModuleNotFoundError` tracebacks
instead of the docs.

This is what broke py-feat.org's Plotting page: CI pinned `marimo-book>=0.1.24`,
0.1.25 shipped (a `sync-releases`-only change), the floating pull invalidated
the whole cache, and the feat-less build executed and failed.

## Fix

Key the render signature on a hand-bumped `_RENDER_OUTPUT_VERSION = "1"` constant
instead of the package version. Bump it only when the export output itself
changes. Upgrading marimo-book no longer forces a re-render (and re-execution of
heavy notebooks) unless the render output actually changed.

The local `BuildCache` (`.marimo_book_cache`) keeps its version-keying — it's a
cheap, auto-rebuilt local cache, not the committed artifact.

## Tests

- `test_render_body_sig_ignores_package_version` — version bump alone no longer changes the signature
- `test_render_body_sig_changes_with_render_output_version` — bumping the contract version still invalidates
- Full suite: 293 passed.