### PR TITLE
feat(theme): add brand logo, favicon, and footer mark

### DIFF
--- a/docs/book.yml
+++ b/docs/book.yml
@@ -15,6 +15,13 @@ repo: https://github.com/ljchang/marimo-book
 branch: main
 url: https://marimobook.org/
 
+# Brand marks. Recolored from the source kit's classic-indigo (#3f51b5)
+# to the site's brand indigo (#6366f1) so the logo matches the palette
+# below. The icon (book/"M") rides in the header next to the text title;
+# the favicon keeps a white tile so it reads on dark browser tabs.
+logo: images/marimo-book-icon.svg
+favicon: images/marimo-book-favicon.svg
+
 theme:
   palette:
     primary: "#6366f1"   # indigo 500 — muted violet accent

--- a/docs/images/marimo-book-favicon.svg
+++ b/docs/images/marimo-book-favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="64" height="64" role="img" aria-label="marimo-book favicon">
+  <rect width="100" height="100" rx="22" fill="#ffffff"></rect>
+  <circle cx="50" cy="50" r="38" fill="none" stroke="#6366f1" stroke-width="8"></circle>
+  <path d="M31 37 L49 52 L49 65 Q40 65 31 58 Z" fill="#6366f1"></path><path d="M69 37 L51 52 L51 65 Q60 65 69 58 Z" fill="#6366f1"></path>
+</svg>

--- a/docs/images/marimo-book-icon.svg
+++ b/docs/images/marimo-book-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="512" height="512" role="img" aria-label="marimo-book icon">
+  <circle cx="50" cy="50" r="40" fill="none" stroke="#6366f1" stroke-width="7"></circle>
+  <path d="M30 35 L49 52 L49 67 Q39.5 67 30 59 Z" fill="#6366f1"></path><path d="M70 35 L51 52 L51 67 Q60.5 67 70 59 Z" fill="#6366f1"></path>
+</svg>

--- a/src/marimo_book/assets/extra.css
+++ b/src/marimo_book/assets/extra.css
@@ -269,6 +269,23 @@
   letter-spacing: -0.01em;
 }
 
+/* Header logo: larger mark, snug to the title. Material ships a 1.2rem logo
+   with a wide gap before the site title (the title carries its own 1.25rem
+   left margin), so the icon + wordmark drift apart. Enlarge the mark and pull
+   the two together so they read as one lockup. The title rule is scoped with
+   `.md-logo ~` so books *without* a logo keep Material's default spacing. */
+.md-header__button.md-logo {
+  padding-right: 0.1rem;
+}
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg {
+  height: 1.85rem;
+  width: 1.85rem;
+}
+.md-header__button.md-logo ~ .md-header__title {
+  margin-left: 0.15rem;
+}
+
 /* --- Admonitions: thin left stripe, no heavy fill ------------------------ */
 .md-typeset .admonition,
 .md-typeset details {

--- a/src/marimo_book/shell.py
+++ b/src/marimo_book/shell.py
@@ -84,8 +84,24 @@ def _build_config(
     # Always credit marimo-book in the footer (alongside any user copyright),
     # linking back to the project site. Material renders HTML in `copyright`
     # and shows it next to its own "Made with Material for MkDocs" notice.
+    #
+    # The book/"M" mark is inlined as SVG (not an <img src>) on purpose: the
+    # footer renders on every page at a different URL depth and Material does
+    # not rewrite paths inside `copyright`, so a relative src would 404 on
+    # nested pages. `currentColor` makes it inherit the credit-link color —
+    # muted in the footer, brand-indigo on hover — so it reads as one lockup
+    # with the wordmark and adapts to each book's palette and to dark mode.
+    _logo_svg = (
+        '<svg viewBox="0 0 100 100" width="1em" height="1em" aria-hidden="true" '
+        'style="vertical-align:-0.18em;margin-right:0.35em">'
+        '<circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="7"></circle>'
+        '<path d="M30 35 L49 52 L49 67 Q39.5 67 30 59 Z" fill="currentColor"></path>'
+        '<path d="M70 35 L51 52 L51 67 Q60.5 67 70 59 Z" fill="currentColor"></path>'
+        "</svg>"
+    )
     _attribution = (
-        'Made with <a href="https://marimobook.org" target="_blank" rel="noopener">Marimo-Book</a>'
+        'Made with <a href="https://marimobook.org" target="_blank" rel="noopener">'
+        f"{_logo_svg}Marimo-Book</a>"
     )
     cfg["copyright"] = f"{book.copyright} · {_attribution}" if book.copyright else _attribution
     # Drop Material's "Made with Material for MkDocs" footer notice — the


### PR DESCRIPTION
## What

Adds the marimo-book brand logo across the site.

| Where | Change |
|---|---|
| **Header** | Book/"M" icon next to the site title — enlarged (`1.2rem → 1.85rem`) and snugged up so the icon + wordmark read as one lockup. |
| **Browser tab** | SVG favicon with a white tile (reads on dark tabs). |
| **Footer** | Inline mark before the "Made with Marimo-Book" credit. |

## Color

The logo kit shipped in classic Material indigo (`#3f51b5`); the site brand is `#6366f1`. Recolored the marks to `#6366f1` so the logo **matches the existing palette** rather than restyling every page.

## Notes for reviewers

- **No Python logic changed** beyond the footer attribution string (`shell.py`). The `logo`/`favicon` plumbing already existed; this just sets the keys and stages `docs/images/`.
- **Footer mark is inline SVG, not `<img src>`** — the footer renders at every URL depth and Material doesn't rewrite paths inside `copyright`, so a relative src would 404 on nested pages. Verified identical on `/quickstart/`. `currentColor` makes it inherit the credit-link color (muted, brand-indigo on hover).
- **Header CSS lives in the shipped `extra.css`** (the file the docs render through) and benefits every book; the title-margin rule is scoped with `.md-logo ~` so logo-less books keep Material's default spacing.
- Verified in light + dark mode; `293 passed`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)