### PR TITLE
Quick wins: dep hygiene, export timeout, theme + progress polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`defaults.execution_timeout`** (seconds, default `600`, `null` disables)
+  bounds every `marimo export` subprocess — a notebook stuck in an infinite
+  loop or a hung download previously stalled `build`/`serve`/CI forever with
+  no diagnostic. Books whose notebooks legitimately run longer should raise
+  the knob (or disable it) in `book.yml`.
+- **Per-notebook progress lines** during `build` and `serve` rebuilds
+  (`[2/7] rendering content/ch2.py...`), so long notebook builds no longer
+  look hung.
+- **Theme polish.** Palettes now follow the OS `prefers-color-scheme` on
+  first visit (the manual toggle still overrides); instant-navigation
+  prefetch, a page-load progress bar, and a back-to-top button are enabled.
+
+### Fixed
+
+- **Declared `tomlkit` and `markdown` as direct dependencies** — both are
+  imported directly but were only present transitively via marimo/mkdocs, so
+  an upstream dependency shuffle could have crashed every build at import
+  time. Dropped unused `jinja2` and `pybtex`.
+
 ## [0.1.26] — 2026-06-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,13 @@ dependencies = [
     "typer>=0.12",
     "pydantic>=2.6",
     "pyyaml>=6.0",
-    "jinja2>=3.1",
+    # Used directly (transforms/pep723.py, transforms/precompute.py) but
+    # historically only present transitively via marimo / mkdocs. Declare
+    # them so an upstream dependency shuffle can't break our imports.
+    "tomlkit>=0.12",
+    "markdown>=3.5",
     "beautifulsoup4>=4.12",
     "lxml>=5.0",
-    "pybtex>=0.24",
     # 0.23.6 ships marimo-team/marimo#9409, which makes
     # `MarimoIslandGenerator.from_file()` propagate the notebook
     # filename so `__file__` / `mo.notebook_dir()` resolve correctly on

--- a/src/marimo_book/cli.py
+++ b/src/marimo_book/cli.py
@@ -266,6 +266,7 @@ def build(
         book_dir=book_dir,
         sandbox_override=sandbox,
         rebuild=rebuild or clean,
+        on_progress=_echo_progress,
     )
     typer.echo(
         f"Preprocessing '{book.title}' ({_count_toc(book.toc)} pages, "
@@ -396,7 +397,13 @@ def serve(
     book_dir = book_file.resolve().parent
     site_src = book_dir / "_site_src"
 
-    pre = Preprocessor(book, book_dir=book_dir, sandbox_override=sandbox, rebuild=rebuild)
+    pre = Preprocessor(
+        book,
+        book_dir=book_dir,
+        sandbox_override=sandbox,
+        rebuild=rebuild,
+        on_progress=_echo_progress,
+    )
     typer.echo(
         f"Preprocessing '{book.title}' ({_count_toc(book.toc)} pages, "
         f"deps={'sandbox' if pre.sandbox else 'env'})..."
@@ -432,6 +439,7 @@ def serve(
             site_src=site_src,
             on_report=_watcher_report_callback,
             sandbox_override=sandbox,
+            on_progress=_echo_progress,
         )
 
     try:
@@ -448,6 +456,11 @@ def serve(
                 mkdocs_proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 mkdocs_proc.kill()
+
+
+def _echo_progress(message: str) -> None:
+    """Per-notebook progress line from the preprocessor (see on_progress)."""
+    typer.echo(f"  {message}")
 
 
 def _report_build(report) -> None:

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -321,6 +321,12 @@ class Defaults(BaseModel):
     # don't surface as visible stderr blocks in the rendered page. Off by
     # default so existing books don't lose visible warnings unexpectedly.
     suppress_warnings: bool = False
+    # Wall-clock cap (seconds) on each ``marimo export`` subprocess. A
+    # notebook stuck in an infinite loop or a hung download otherwise
+    # stalls build/serve/CI forever with no diagnostic. ``null`` disables
+    # the cap (e.g. books whose ``mode: cached`` renders legitimately run
+    # for hours on a GPU box).
+    execution_timeout: float | None = 600.0
 
 
 # --- TOC entries (discriminated union) ---------------------------------------

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -26,7 +26,7 @@ import hashlib
 import json
 import shutil
 import sys
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError
@@ -454,11 +454,16 @@ class Preprocessor:
         book_dir: Path,
         sandbox_override: bool | None = None,
         rebuild: bool = False,
+        on_progress: Callable[[str], None] | None = None,
     ) -> None:
         self.book = book
         self.book_dir = Path(book_dir).resolve()
         # None = honour book.yml's dependencies.mode; True/False overrides.
         self.sandbox_override = sandbox_override
+        # Called with a human-readable line before/after slow per-entry work
+        # (notebook exports take seconds-to-minutes; without this, build and
+        # serve look hung). None = silent.
+        self.on_progress = on_progress
         # When True, every TOC entry is re-rendered regardless of cache state.
         # The cache is still updated so future builds without --rebuild benefit.
         self.rebuild = rebuild
@@ -473,6 +478,10 @@ class Preprocessor:
         if self.sandbox_override is not None:
             return self.sandbox_override
         return self.book.dependencies.mode == "sandbox"
+
+    def _progress(self, message: str) -> None:
+        if self.on_progress is not None:
+            self.on_progress(message)
 
     # --- public API ----------------------------------------------------------
 
@@ -532,16 +541,25 @@ class Preprocessor:
         cache = BuildCache(self.book_dir, self.book, force_rebuild=self.rebuild)
         rendered_store = RenderedStore(self.book_dir)
 
+        # Progress lines cover only .py entries — Markdown stages in ~10 ms,
+        # notebooks in seconds-to-minutes.
+        py_total = sum(1 for e in file_entries if e.file.suffix == ".py")
+        py_seen = 0
+
         for entry in file_entries:
             src_rel = str(entry.file)
             src_abs = (self.book_dir / entry.file).resolve()
             out_rel = _doc_relpath_for(entry.file, index_source=index_source).as_posix()
             mode = entry.effective_mode(self.book.defaults.mode)
+            if entry.file.suffix == ".py":
+                py_seen += 1
+            tag = f"[{py_seen}/{py_total}]"
             try:
                 # mode=cached: source outputs from the committed _rendered/
                 # artifact instead of executing the notebook. Never touches the
                 # transient cache or precompute (the committed body is final).
                 if entry.file.suffix == ".py" and mode == "cached":
+                    self._progress(f"{tag} {src_rel} (committed render)")
                     self._stage_cached(
                         entry,
                         src_rel,
@@ -559,8 +577,11 @@ class Preprocessor:
                 # Notebook entries are the only ones worth caching: marimo
                 # export takes seconds-to-minutes, vs ~10 ms for Markdown.
                 if entry.file.suffix == ".py" and cache.is_hit(src_rel, src_abs, docs_dir):
+                    self._progress(f"{tag} {src_rel} (cache hit)")
                     report.pages_cached += 1
                 else:
+                    if entry.file.suffix == ".py":
+                        self._progress(f"{tag} rendering {src_rel}...")
                     stage_page(
                         self.book,
                         self.book_dir,

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -808,6 +808,7 @@ class Preprocessor:
             max_combinations=cfg.max_combinations_per_page,
             sandbox=self.sandbox,
             suppress_warnings=self.book.defaults.suppress_warnings,
+            timeout=self.book.defaults.execution_timeout,
         )
         if result.skipped:
             report.warnings.append(f"{entry.file}: {result.skip_reason}")
@@ -1089,6 +1090,7 @@ def _render_marimo(src: Path, book: Book, *, sandbox: bool = False) -> str:
         src,
         sandbox=sandbox,
         suppress_warnings=book.defaults.suppress_warnings,
+        timeout=book.defaults.execution_timeout,
     )
     return cells_to_markdown(
         exp,

--- a/src/marimo_book/shell.py
+++ b/src/marimo_book/shell.py
@@ -230,7 +230,10 @@ def _build_config(
 
 
 def _theme_block(book: Book) -> dict[str, Any]:
+    # ``media`` keys make the first paint follow the OS preference; the
+    # manual toggle still overrides (Material persists the choice).
     palette_default: dict[str, Any] = {
+        "media": "(prefers-color-scheme: light)",
         "scheme": "default",
         "toggle": {
             "icon": "material/weather-sunny",
@@ -238,6 +241,7 @@ def _theme_block(book: Book) -> dict[str, Any]:
         },
     }
     palette_slate: dict[str, Any] = {
+        "media": "(prefers-color-scheme: dark)",
         "scheme": "slate",
         "toggle": {
             "icon": "material/weather-night",

--- a/src/marimo_book/shell.py
+++ b/src/marimo_book/shell.py
@@ -266,6 +266,11 @@ def _theme_block(book: Book) -> dict[str, Any]:
             "navigation.path",
             "navigation.footer",
             "navigation.instant",
+            # Prefetch on hover + a top progress bar for slow page loads
+            # (WASM pages especially), and a back-to-top button on mobile.
+            "navigation.instant.prefetch",
+            "navigation.instant.progress",
+            "navigation.top",
             "navigation.tracking",
             "search.suggest",
             "search.highlight",

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -42,6 +42,11 @@ from .callouts import render_callout_html
 # notebook. The key names we care about for v0.1:
 _HIDE_CODE = "hide_code"
 
+# Default wall-clock cap per export subprocess; ``Defaults.execution_timeout``
+# overrides it per book. Applied even when callers don't thread the knob so
+# no call site can hang unboundedly by accident.
+DEFAULT_EXPORT_TIMEOUT: float = 600.0
+
 
 @dataclass
 class ExportedNotebook:
@@ -58,6 +63,7 @@ def export_notebook(
     include_outputs: bool = True,
     sandbox: bool = False,
     suppress_warnings: bool = False,
+    timeout: float | None = DEFAULT_EXPORT_TIMEOUT,
 ) -> ExportedNotebook:
     """Run ``marimo export ipynb`` and return the parsed notebook JSON.
 
@@ -94,7 +100,16 @@ def export_notebook(
     with tempfile.TemporaryDirectory(prefix="marimo_book_") as tmp_dir:
         tmp_out = Path(tmp_dir) / f"{py_path.stem}.ipynb"
         cmd.extend(["-o", str(tmp_out)])
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=False, env=env, timeout=timeout
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"marimo export ipynb timed out after {timeout:g}s for {py_path}. "
+                "Raise defaults.execution_timeout in book.yml (or set it to null "
+                "to disable) if this notebook legitimately runs longer."
+            ) from exc
         # marimo exits non-zero when *some* cells fail to execute but still
         # produces a valid ipynb with error outputs. We accept that case
         # because the preprocessor then emits the error cell visibly.
@@ -117,6 +132,7 @@ def export_notebook_with_overrides(
     include_outputs: bool = True,
     sandbox: bool = False,
     suppress_warnings: bool = False,
+    timeout: float | None = DEFAULT_EXPORT_TIMEOUT,
 ) -> ExportedNotebook:
     """Run ``marimo export`` against ``rewritten_source`` instead of the file.
 
@@ -137,6 +153,7 @@ def export_notebook_with_overrides(
             include_outputs=include_outputs,
             sandbox=sandbox,
             suppress_warnings=suppress_warnings,
+            timeout=timeout,
         )
 
 

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -566,6 +566,7 @@ def precompute_page(
     max_combinations: int,
     sandbox: bool = False,
     suppress_warnings: bool = False,
+    timeout: float | None = None,
 ) -> PrecomputeResult:
     """Re-export a notebook once per (widget, value), return the staged body.
 
@@ -595,7 +596,9 @@ def precompute_page(
     t0 = time.monotonic()
     source = py_path.read_text(encoding="utf-8")
 
-    base_export = export_notebook(py_path, sandbox=sandbox, suppress_warnings=suppress_warnings)
+    base_export = export_notebook(
+        py_path, sandbox=sandbox, suppress_warnings=suppress_warnings, timeout=timeout
+    )
     base_segments = cells_to_markdown_segments(base_export)
     base_seconds = time.monotonic() - t0
     base_diff_key_by_idx = {idx: _diff_key(html) for idx, html in base_segments}
@@ -653,6 +656,7 @@ def precompute_page(
                     rewritten_source=rewritten,
                     sandbox=sandbox,
                     suppress_warnings=suppress_warnings,
+                    timeout=timeout,
                 )
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001 — keep the build alive on a single bad value
@@ -768,6 +772,7 @@ def precompute_page(
                     rewritten_source=rewritten,
                     sandbox=sandbox,
                     suppress_warnings=suppress_warnings,
+                    timeout=timeout,
                 )
                 segments = cells_to_markdown_segments(export)
             except Exception:  # noqa: BLE001

--- a/src/marimo_book/watcher.py
+++ b/src/marimo_book/watcher.py
@@ -69,12 +69,15 @@ class RebuildHandler(FileSystemEventHandler):
         debounce_seconds: float = 0.4,
         on_report: Callable[[BuildReport], None] | None = None,
         sandbox_override: bool | None = None,
+        on_progress: Callable[[str], None] | None = None,
     ) -> None:
         self.book_file = Path(book_file).resolve()
         self.book_dir = Path(book_dir).resolve()
         self.site_src = Path(site_src).resolve()
         self.debounce = debounce_seconds
         self.on_report = on_report
+        # Forwarded to each rebuild's Preprocessor for per-notebook progress.
+        self.on_progress = on_progress
         # Forwarded to every rebuild's Preprocessor so `marimo-book serve
         # --sandbox` / `--no-sandbox` sticks across file-change rebuilds
         # instead of reverting to book.yml's mode.
@@ -185,6 +188,7 @@ class RebuildHandler(FileSystemEventHandler):
                 book,
                 book_dir=self.book_dir,
                 sandbox_override=self.sandbox_override,
+                on_progress=self.on_progress,
             ).build(out_dir=self.site_src)
         except Exception as exc:  # noqa: BLE001 — keep the watcher alive
             self._emit_error(f"preprocessor crashed: {exc.__class__.__name__}: {exc}")
@@ -211,6 +215,7 @@ def start_watcher(
     site_src: Path,
     on_report: Callable[[BuildReport], None] | None = None,
     sandbox_override: bool | None = None,
+    on_progress: Callable[[str], None] | None = None,
 ) -> tuple[Observer, RebuildHandler]:
     """Install the rebuild handler on a watchdog Observer and start it.
 
@@ -223,6 +228,7 @@ def start_watcher(
         site_src=site_src,
         on_report=on_report,
         sandbox_override=sandbox_override,
+        on_progress=on_progress,
     )
     observer = Observer()
     # Watch content/ recursively for .md / .py changes.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -203,3 +203,20 @@ def test_api_docs_full_roundtrip() -> None:
     assert book.api_docs.docstring_style == "numpy"
     assert book.api_docs.options == {"members_order": "source"}
     assert book.api_docs.inventories == ["https://docs.python.org/3/objects.inv"]
+
+
+def test_execution_timeout_default_and_override(tmp_path: Path) -> None:
+    book_yml = tmp_path / "book.yml"
+    book_yml.write_text(yaml.safe_dump({"title": "T", "toc": [{"file": "a.md"}]}))
+    assert load_book(book_yml).defaults.execution_timeout == 600.0
+
+    book_yml.write_text(
+        yaml.safe_dump(
+            {
+                "title": "T",
+                "defaults": {"execution_timeout": None},
+                "toc": [{"file": "a.md"}],
+            }
+        )
+    )
+    assert load_book(book_yml).defaults.execution_timeout is None

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -594,3 +594,32 @@ def test_mkdocs_yml_wires_blog_plugins_and_nav(tmp_path: Path) -> None:
     assert "blog" in names and "tags" in names and "rss" in names
     assert names.index("blog") < names.index("rss")
     assert any(isinstance(n, dict) and n.get("News") == "blog/index.md" for n in cfg["nav"])
+
+
+# --- build progress reporting -------------------------------------------------
+
+
+def test_on_progress_reports_notebook_renders(tmp_path: Path) -> None:
+    _minimal_book(tmp_path)
+    shutil.copy(NOTEBOOK_FIXTURE, tmp_path / "content" / "nb.py")
+    book = Book.model_validate(
+        {
+            "title": "Test",
+            "toc": [{"file": "content/intro.md"}, {"file": "content/nb.py"}],
+        }
+    )
+
+    messages: list[str] = []
+    pre = Preprocessor(book, book_dir=tmp_path, on_progress=messages.append)
+    report = pre.build(out_dir=tmp_path / "_site_src")
+
+    assert report.ok
+    assert any("[1/1] rendering content/nb.py" in m for m in messages)
+
+    # Second build: the cache hit surfaces instead of a render line.
+    messages.clear()
+    pre = Preprocessor(book, book_dir=tmp_path, on_progress=messages.append)
+    report = pre.build(out_dir=tmp_path / "_site_src")
+
+    assert report.ok
+    assert any("[1/1] content/nb.py (cache hit)" in m for m in messages)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,18 @@
+"""Tests for the generated mkdocs.yml (shell.py)."""
+
+from __future__ import annotations
+
+from marimo_book.config import Book
+from marimo_book.shell import _theme_block
+
+
+def _book(**overrides) -> Book:
+    data = {"title": "T", "toc": [{"file": "content/a.md"}], **overrides}
+    return Book.model_validate(data)
+
+
+def test_palettes_follow_system_color_scheme() -> None:
+    palettes = _theme_block(_book())["palette"]
+    media = {p["scheme"]: p.get("media") for p in palettes}
+    assert media["default"] == "(prefers-color-scheme: light)"
+    assert media["slate"] == "(prefers-color-scheme: dark)"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -16,3 +16,10 @@ def test_palettes_follow_system_color_scheme() -> None:
     media = {p["scheme"]: p.get("media") for p in palettes}
     assert media["default"] == "(prefers-color-scheme: light)"
     assert media["slate"] == "(prefers-color-scheme: dark)"
+
+
+def test_nav_features_include_prefetch_progress_and_top() -> None:
+    features = _theme_block(_book())["features"]
+    assert "navigation.instant.prefetch" in features
+    assert "navigation.instant.progress" in features
+    assert "navigation.top" in features

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from marimo_book.config import Book
 from marimo_book.launch_buttons import render_button_row
@@ -543,3 +546,20 @@ def test_anywidget_escaped_under_text_markdown_routes_to_html() -> None:
     assert "&lt;marimo-anywidget" not in out
     # Literal kwarg from cell source seeds initial state.
     assert '"height": 320' in out
+
+
+# --- export timeout ----------------------------------------------------------
+
+
+def test_export_notebook_timeout_raises_actionable_error(monkeypatch, tmp_path: Path) -> None:
+    from marimo_book.transforms import marimo_export
+
+    nb = tmp_path / "hang.py"
+    nb.write_text("import marimo\napp = marimo.App()\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+    monkeypatch.setattr(marimo_export.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="timed out after 1s"):
+        marimo_export.export_notebook(nb, timeout=1)


### PR DESCRIPTION
## Summary
- **Dependency hygiene**: declare `tomlkit` + `markdown` as direct deps (both imported directly, previously only present transitively via marimo/mkdocs — an upstream shuffle would have crashed every build at import time); drop unused `jinja2` + `pybtex`
- **`defaults.execution_timeout`** (seconds, default 600, `null` disables): bounds every `marimo export` subprocess so a notebook stuck in an infinite loop or hung download can't stall build/serve/CI forever. Threaded through static render, `mode: cached` render, blog posts, and each precompute value re-export
- **Theme**: palettes follow the OS `prefers-color-scheme` on first paint (manual toggle still overrides); add `navigation.instant.prefetch`, `navigation.instant.progress`, `navigation.top`
- **Build UX**: per-notebook `[i/N] rendering content/ch2.py...` / `(cache hit)` / `(committed render)` progress lines during `build`, `serve`'s initial build, and watcher rebuilds

## Behavior change
Notebooks that legitimately execute >10 min now need `defaults.execution_timeout` raised (or set to `null`). Called out in CHANGELOG.

## Test plan
- 5 new tests (timeout error path, config knob round-trip, palette media keys, nav features, progress callback incl. cache-hit path); suite now 298 passing
- `ruff check` + `ruff format --check` clean
- `marimo-book build -b docs/book.yml --strict` green locally (needs `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` on macOS for the social-cards cairo dep — unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEsxCZ7dPygmxHWmu4PbxF