### PR TITLE
build --strict fails on notebook cell errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[linkcheck,social,autorefs,pdf,blog]'
+      - name: Install demo notebook deps (drawdata/anywidget used by widgets.py)
+        # Without these the widgets page renders ModuleNotFoundError cells,
+        # which `build --strict` now (correctly) fails on. Mirrors docs.yml.
+        run: pip install drawdata anywidget
       - name: Build docs --strict (also exercises social-card generation)
         run: marimo-book build -b docs/book.yml --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`build --strict` now fails when a notebook cell raises.** Previously a
+  runtime error rendered its traceback into the published page while CI
+  stayed green (mkdocs strict only checks nav/links). Non-strict builds and
+  `marimo-book render` warn; pages that intentionally demonstrate exceptions
+  opt out with `allow_errors: true` on the TOC entry.
 - **`defaults.execution_timeout`** (seconds, default `600`, `null` disables)
   bounds every `marimo export` subprocess — a notebook stuck in an infinite
   loop or a hung download previously stalled `build`/`serve`/CI forever with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime error rendered its traceback into the published page while CI
   stayed green (mkdocs strict only checks nav/links). Non-strict builds and
   `marimo-book render` warn; pages that intentionally demonstrate exceptions
-  opt out with `allow_errors: true` on the TOC entry.
+  opt out with `allow_errors: true` on the TOC entry. The verdict survives
+  caching: raising cells are recorded in the build cache and in `_rendered/`
+  manifest entries and replayed on hits, so a cached page can't dodge the
+  strict gate (artifacts rendered before this release are grandfathered
+  until the next `marimo-book render`). WASM pages are exempt — the islands
+  runtime re-executes in the browser. Diagnostics point at the code-cell
+  ordinal (`code cell 3`), counting only code cells.
 - **`defaults.execution_timeout`** (seconds, default `600`, `null` disables)
-  bounds every `marimo export` subprocess — a notebook stuck in an infinite
-  loop or a hung download previously stalled `build`/`serve`/CI forever with
-  no diagnostic. Books whose notebooks legitimately run longer should raise
-  the knob (or disable it) in `book.yml`.
+  bounds every notebook execution — `marimo export` subprocesses and the
+  in-process WASM island build — a notebook stuck in an infinite loop or a
+  hung download previously stalled `build`/`serve`/CI forever with no
+  diagnostic. Books whose notebooks legitimately run longer should raise the
+  knob (or disable it) in `book.yml`. The knob is excluded from cache and
+  `_rendered/` signatures: tuning it never invalidates committed renders.
+- **`marimo-book render` progress + labels.** Per-notebook
+  `[i/N] rendering …` lines while heavy cached notebooks execute, and its
+  warnings are no longer mislabeled `stale:` outside `--check`. A crashing
+  blog post now lands in the report like TOC entries instead of aborting the
+  whole build.
 - **Per-notebook progress lines** during `build` and `serve` rebuilds
   (`[2/7] rendering content/ch2.py...`), so long notebook builds no longer
   look hung.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,27 @@ If a PR introduces a new optional extra (like `[autorefs]`), update
 both `.github/workflows/ci.yml` and `.github/workflows/docs.yml` to
 install it (the docs job needs every extra the docs site uses).
 
+## Build strictness and execution bounds (since 0.1.27)
+
+- **`build --strict` fails when a notebook cell raises.** The traceback
+  still renders into the page (authoring aid), but it lands in
+  `report.errors` under strict. Non-strict builds, blog posts, and
+  `marimo-book render` warn. Opt out per TOC entry with
+  `allow_errors: true` (for lessons that demo exceptions). The verdict
+  survives caching: raising cells are recorded in the transient cache
+  AND in `_rendered/` manifest entries and replayed on hits — do not
+  remove that replay or a cached strict run will silently pass. WASM
+  pages are exempt (islands pipeline produces no ipynb error outputs).
+  The docs CI job installs `drawdata anywidget` because without them
+  the demo notebooks raise and now fail the strict docs build.
+- **`defaults.execution_timeout`** (seconds, default 600, `null`
+  disables) bounds every notebook execution: `marimo export`
+  subprocesses AND the in-process WASM island build. It is deliberately
+  **excluded from `_book_signature` and `_render_body_signature`** — it
+  can abort a render but never change its output, so tuning it must not
+  invalidate caches or committed `_rendered/` bodies. Keep any future
+  "how long/how" knobs out of those signatures too.
+
 ## Feature flags users can opt into via `book.yml`
 
 | Flag | Effect | Extra needed |

--- a/src/marimo_book/cli.py
+++ b/src/marimo_book/cli.py
@@ -323,11 +323,14 @@ def render(
     """
     book = _load_or_exit(book_file)
     book_dir = book_file.resolve().parent
-    pre = Preprocessor(book, book_dir=book_dir)
+    pre = Preprocessor(book, book_dir=book_dir, on_progress=_echo_progress)
     report = pre.render_cached(check_only=check)
 
+    # In --check mode every warning is a staleness report; in render mode
+    # warnings are other diagnostics (e.g. raising cells) — label accordingly.
+    warn_label = "stale" if check else "warning"
     for warn in report.warnings:
-        typer.echo(f"  stale: {warn}", err=True)
+        typer.echo(f"  {warn_label}: {warn}", err=True)
     for err in report.errors:
         typer.echo(f"  error: {err}", err=True)
 

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -346,6 +346,10 @@ class FileEntry(BaseModel):
     # (no execution at build). Markdown pages ignore this field.
     mode: Literal["static", "wasm", "cached"] | None = None
     hidden: bool = False
+    # Cells on this page are *expected* to raise (e.g. a lesson that
+    # demonstrates exceptions). Suppresses the cell-error warning and the
+    # ``build --strict`` failure for this entry only.
+    allow_errors: bool = False
 
     def effective_mode(self, default_mode: str) -> str:
         """Resolve this entry's render mode against the book-wide default."""

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -108,7 +108,8 @@ class BuildReport:
 # --- build cache ------------------------------------------------------------
 
 # Bumped whenever the cache schema or hit-decision rules change.
-_CACHE_SCHEMA_VERSION = 1
+# v2: entries record ``cell_errors`` so hits can replay the strict/warn verdict.
+_CACHE_SCHEMA_VERSION = 2
 _CACHE_DIR_NAME = ".marimo_book_cache"
 _CACHE_FILE_NAME = "manifest.json"
 
@@ -167,7 +168,9 @@ class BuildCache:
         self.dirty = True
         return True
 
-    def record(self, src_rel: str, src_abs: Path, out_rel: str) -> None:
+    def record(
+        self, src_rel: str, src_abs: Path, out_rel: str, *, cell_errors: list[dict] | None = None
+    ) -> None:
         try:
             mtime = src_abs.stat().st_mtime
             digest = _file_sha256(src_abs)
@@ -178,8 +181,17 @@ class BuildCache:
             "src_hash": digest,
             "out_path": out_rel,
             "rendered_at": datetime.now(UTC).isoformat(timespec="seconds"),
+            # Raising cells observed at render time, replayed on cache hits —
+            # a hit skips the export, and the strict/warn verdict must not
+            # depend on whether the page happened to be cached.
+            "cell_errors": cell_errors or [],
         }
         self.dirty = True
+
+    def recorded_cell_errors(self, src_rel: str) -> list[dict]:
+        entry = self.entries.get(src_rel) or {}
+        raw = entry.get("cell_errors")
+        return raw if isinstance(raw, list) else []
 
     def save(self) -> None:
         if not self.dirty and self.path.exists():
@@ -214,6 +226,20 @@ class BuildCache:
             self.entries = loaded
 
 
+def _cell_errors_to_dicts(cell_errors: list[CellError]) -> list[dict]:
+    return [{"cell_index": e.cell_index, "ename": e.ename, "evalue": e.evalue} for e in cell_errors]
+
+
+def _cell_errors_from_dicts(raw: list[dict]) -> list[CellError]:
+    return [
+        CellError(
+            int(d.get("cell_index", 0)), str(d.get("ename", "Error")), str(d.get("evalue", ""))
+        )
+        for d in raw
+        if isinstance(d, dict)
+    ]
+
+
 def _resolve_tool_version() -> str:
     """Read the installed package version; fall back to a sentinel if missing."""
     try:
@@ -234,9 +260,13 @@ def _book_signature(book: Book) -> str:
     Excludes title / palette / fonts / analytics — those only affect
     ``mkdocs.yml`` emission, which is always re-run and cheap.
     """
+    defaults = book.defaults.model_dump(mode="json")
+    # execution_timeout bounds how long a render may take, never what it
+    # renders — excluding it keeps caches valid when the knob changes.
+    defaults.pop("execution_timeout", None)
     relevant: dict = {
         "widget_defaults": book.widget_defaults,
-        "defaults": book.defaults.model_dump(mode="json"),
+        "defaults": defaults,
         "dependencies": book.dependencies.model_dump(mode="json"),
         "launch_buttons": book.launch_buttons.model_dump(mode="json"),
         "precompute": book.precompute.model_dump(mode="json"),
@@ -273,8 +303,14 @@ def _render_body_signature(book: Book) -> str:
     package release. Stored with each ``RenderedStore`` entry so a build can
     tell a committed body is stale even when the source bytes are unchanged.
     """
+    defaults = book.defaults.model_dump(mode="json")
+    # execution_timeout can only abort a render, never change its output —
+    # including it would mark every committed body stale (and force a costly
+    # re-execution of heavy notebooks) each time the knob is tuned or a
+    # release adds/renames it. Same rationale as _RENDER_OUTPUT_VERSION.
+    defaults.pop("execution_timeout", None)
     relevant: dict = {
-        "defaults": book.defaults.model_dump(mode="json"),
+        "defaults": defaults,
         "dependencies": book.dependencies.model_dump(mode="json"),
         "widget_defaults": book.widget_defaults,
         "render_output_version": _RENDER_OUTPUT_VERSION,
@@ -485,6 +521,31 @@ class Preprocessor:
         if self.on_progress is not None:
             self.on_progress(message)
 
+    def _apply_cell_error_policy(
+        self,
+        entry: FileEntry,
+        cell_errors: list[CellError],
+        report: BuildReport,
+        *,
+        strict: bool,
+        note: str,
+    ) -> None:
+        """Route a page's raising cells to the report.
+
+        ``strict`` makes them build failures; otherwise they are warnings
+        suffixed with ``note`` (what the visible traceback ends up in).
+        ``allow_errors: true`` on the entry silences both — for pages that
+        intentionally demonstrate exceptions.
+        """
+        if not cell_errors or entry.allow_errors:
+            return
+        sink = report.errors if strict else report.warnings
+        for e in cell_errors:
+            sink.append(
+                f"{entry.file}: code cell {e.cell_index} raised {e.ename}: {e.evalue}"
+                + ("" if strict else f" ({note})")
+            )
+
     # --- public API ----------------------------------------------------------
 
     def build(
@@ -580,6 +641,16 @@ class Preprocessor:
                 # export takes seconds-to-minutes, vs ~10 ms for Markdown.
                 if entry.file.suffix == ".py" and cache.is_hit(src_rel, src_abs, docs_dir):
                     self._progress(f"{tag} {src_rel} (cache hit)")
+                    # Replay cell errors recorded at render time — a hit skips
+                    # the export entirely, so without this a page that failed
+                    # `--strict` once would pass on the very next (cached) run.
+                    self._apply_cell_error_policy(
+                        entry,
+                        _cell_errors_from_dicts(cache.recorded_cell_errors(src_rel)),
+                        report,
+                        strict=strict,
+                        note="traceback published to page",
+                    )
                     report.pages_cached += 1
                 else:
                     if entry.file.suffix == ".py":
@@ -588,19 +659,9 @@ class Preprocessor:
                     # A raising cell renders its traceback into the page (a
                     # deliberate authoring aid) but must not slip through CI:
                     # strict makes it a build failure, non-strict a warning.
-                    def _on_cell_errors(
-                        cell_errors: list[CellError], *, _entry: FileEntry = entry
-                    ) -> None:
-                        if _entry.allow_errors:
-                            return
-                        sink = report.errors if strict else report.warnings
-                        for e in cell_errors:
-                            sink.append(
-                                f"{_entry.file}: cell {e.cell_index} raised "
-                                f"{e.ename}: {e.evalue}"
-                                + ("" if strict else " (traceback published to page)")
-                            )
-
+                    # Collected (not routed) here so the raw list can also be
+                    # recorded in the cache for replay on future hits.
+                    collected_errors: list[CellError] = []
                     stage_page(
                         self.book,
                         self.book_dir,
@@ -609,10 +670,22 @@ class Preprocessor:
                         md_basenames=md_basenames,
                         sandbox=self.sandbox,
                         index_source=index_source,
-                        on_cell_errors=_on_cell_errors,
+                        on_cell_errors=collected_errors.extend,
+                    )
+                    self._apply_cell_error_policy(
+                        entry,
+                        collected_errors,
+                        report,
+                        strict=strict,
+                        note="traceback published to page",
                     )
                     if entry.file.suffix == ".py":
-                        cache.record(src_rel, src_abs, out_rel)
+                        cache.record(
+                            src_rel,
+                            src_abs,
+                            out_rel,
+                            cell_errors=_cell_errors_to_dicts(collected_errors),
+                        )
                     report.pages_rendered += 1
                 report.pages += 1
 
@@ -676,11 +749,12 @@ class Preprocessor:
         report = BuildReport()
         store = RenderedStore(self.book_dir)
         default_mode = self.book.defaults.mode
-        for entry in _iter_file_entries(self.book.toc):
-            if entry.file.suffix != ".py":
-                continue
-            if entry.effective_mode(default_mode) != "cached":
-                continue
+        targets = [
+            e
+            for e in _iter_file_entries(self.book.toc)
+            if e.file.suffix == ".py" and e.effective_mode(default_mode) == "cached"
+        ]
+        for pos, entry in enumerate(targets, 1):
             src_rel = str(entry.file)
             src_abs = (self.book_dir / entry.file).resolve()
             report.pages += 1
@@ -694,29 +768,37 @@ class Preprocessor:
                     )
                 continue
             try:
+                # These are the notebooks documented to run for hours on a
+                # GPU box — say which one is executing and how many remain.
+                self._progress(f"[{pos}/{len(targets)}] rendering {src_rel}...")
                 # ``render`` runs on the author's machine — a raising cell
                 # would otherwise be committed to ``_rendered/`` unnoticed.
                 # Warn (not error): a demo-exception page is legitimate and
-                # ``allow_errors: true`` silences it entirely.
-                def _on_cell_errors(
-                    cell_errors: list[CellError], *, _entry: FileEntry = entry
-                ) -> None:
-                    if _entry.allow_errors:
-                        return
-                    for e in cell_errors:
-                        report.warnings.append(
-                            f"{_entry.file}: cell {e.cell_index} raised "
-                            f"{e.ename}: {e.evalue} (traceback committed to _rendered/)"
-                        )
-
+                # ``allow_errors: true`` silences it entirely. The raw list is
+                # also stored with the artifact so a later ``build --strict``
+                # can fail on the committed traceback without executing.
+                collected_errors: list[CellError] = []
                 body = render_py_body(
                     self.book,
                     self.book_dir,
                     entry,
                     sandbox=self.sandbox,
-                    on_cell_errors=_on_cell_errors,
+                    on_cell_errors=collected_errors.extend,
                 )
-                store.write(src_rel, src_abs, body, body_sig=self.body_signature)
+                self._apply_cell_error_policy(
+                    entry,
+                    collected_errors,
+                    report,
+                    strict=False,
+                    note="traceback committed to _rendered/",
+                )
+                store.write(
+                    src_rel,
+                    src_abs,
+                    body,
+                    body_sig=self.body_signature,
+                    cell_errors=_cell_errors_to_dicts(collected_errors),
+                )
                 report.pages_rendered += 1
             except Exception as exc:  # noqa: BLE001
                 report.errors.append(f"{entry.file}: {exc.__class__.__name__}: {exc}")
@@ -747,6 +829,16 @@ class Preprocessor:
         authoring still works.
         """
         if store.is_fresh(src_rel, src_abs, body_sig=self.body_signature):
+            # The committed body may contain tracebacks captured at render
+            # time; replay them so the strict gate applies to cached pages
+            # the same as to freshly executed ones.
+            self._apply_cell_error_policy(
+                entry,
+                _cell_errors_from_dicts(store.recorded_cell_errors(src_rel)),
+                report,
+                strict=strict,
+                note="traceback committed to _rendered/",
+            )
             _finalize_page(
                 self.book,
                 self.book_dir,
@@ -775,6 +867,7 @@ class Preprocessor:
             f"rendering fresh (executes). Run `marimo-book render` and commit "
             f"_rendered/ so CI need not execute."
         )
+        collected_errors: list[CellError] = []
         stage_page(
             self.book,
             self.book_dir,
@@ -783,6 +876,14 @@ class Preprocessor:
             md_basenames=md_basenames,
             sandbox=self.sandbox,
             index_source=index_source,
+            on_cell_errors=collected_errors.extend,
+        )
+        self._apply_cell_error_policy(
+            entry,
+            collected_errors,
+            report,
+            strict=False,  # this branch is only reachable when strict is off
+            note="traceback published to page",
         )
         report.pages_rendered += 1
 
@@ -942,11 +1043,18 @@ class Preprocessor:
                 def _on_post_cell_errors(cell_errors: list[CellError], *, _src: Path = src) -> None:
                     for e in cell_errors:
                         report.warnings.append(
-                            f"{_src.name}: cell {e.cell_index} raised "
+                            f"{_src.name}: code cell {e.cell_index} raised "
                             f"{e.ename}: {e.evalue} (traceback published to post)"
                         )
 
-                body = self._render_notebook_body(src, on_cell_errors=_on_post_cell_errors)
+                # Contain per-post render crashes (export timeout, marimo
+                # failure) like TOC entries — one bad post must not abort
+                # the whole build before mkdocs.yml is written.
+                try:
+                    body = self._render_notebook_body(src, on_cell_errors=_on_post_cell_errors)
+                except Exception as exc:  # noqa: BLE001
+                    report.errors.append(f"{src.name}: {exc.__class__.__name__}: {exc}")
+                    continue
                 if meta.title == src.stem:
                     h1 = _first_markdown_heading(body)
                     if h1:
@@ -1083,7 +1191,11 @@ def stage_page(
                 # islands runtime takes over in the browser; the body we
                 # write here contains marimo's CDN-loaded scripts + the
                 # ``<marimo-island>`` web components for each cell.
-                body = render_wasm_page(src_abs, staged_source_path=staged)
+                body = render_wasm_page(
+                    src_abs,
+                    staged_source_path=staged,
+                    timeout=book.defaults.execution_timeout,
+                )
                 apply_rewrites = False
             else:
                 body = _render_marimo(

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -53,8 +53,10 @@ from .rendered_store import RenderedStore
 from .shell import _nav_from_toc, emit_mkdocs_yml
 from .transforms.link_rewrites import apply_link_rewrites
 from .transforms.marimo_export import (
+    CellError,
     cells_to_markdown,
     cleanup_orphan_precompute_dirs,
+    collect_cell_errors,
     export_notebook,
     staged_sibling_file,
 )
@@ -582,6 +584,23 @@ class Preprocessor:
                 else:
                     if entry.file.suffix == ".py":
                         self._progress(f"{tag} rendering {src_rel}...")
+
+                    # A raising cell renders its traceback into the page (a
+                    # deliberate authoring aid) but must not slip through CI:
+                    # strict makes it a build failure, non-strict a warning.
+                    def _on_cell_errors(
+                        cell_errors: list[CellError], *, _entry: FileEntry = entry
+                    ) -> None:
+                        if _entry.allow_errors:
+                            return
+                        sink = report.errors if strict else report.warnings
+                        for e in cell_errors:
+                            sink.append(
+                                f"{_entry.file}: cell {e.cell_index} raised "
+                                f"{e.ename}: {e.evalue}"
+                                + ("" if strict else " (traceback published to page)")
+                            )
+
                     stage_page(
                         self.book,
                         self.book_dir,
@@ -590,6 +609,7 @@ class Preprocessor:
                         md_basenames=md_basenames,
                         sandbox=self.sandbox,
                         index_source=index_source,
+                        on_cell_errors=_on_cell_errors,
                     )
                     if entry.file.suffix == ".py":
                         cache.record(src_rel, src_abs, out_rel)
@@ -674,7 +694,28 @@ class Preprocessor:
                     )
                 continue
             try:
-                body = render_py_body(self.book, self.book_dir, entry, sandbox=self.sandbox)
+                # ``render`` runs on the author's machine — a raising cell
+                # would otherwise be committed to ``_rendered/`` unnoticed.
+                # Warn (not error): a demo-exception page is legitimate and
+                # ``allow_errors: true`` silences it entirely.
+                def _on_cell_errors(
+                    cell_errors: list[CellError], *, _entry: FileEntry = entry
+                ) -> None:
+                    if _entry.allow_errors:
+                        return
+                    for e in cell_errors:
+                        report.warnings.append(
+                            f"{_entry.file}: cell {e.cell_index} raised "
+                            f"{e.ename}: {e.evalue} (traceback committed to _rendered/)"
+                        )
+
+                body = render_py_body(
+                    self.book,
+                    self.book_dir,
+                    entry,
+                    sandbox=self.sandbox,
+                    on_cell_errors=_on_cell_errors,
+                )
                 store.write(src_rel, src_abs, body, body_sig=self.body_signature)
                 report.pages_rendered += 1
             except Exception as exc:  # noqa: BLE001
@@ -868,13 +909,17 @@ class Preprocessor:
                 return True
         return False
 
-    def _render_notebook_body(self, src: Path) -> str:
+    def _render_notebook_body(
+        self, src: Path, on_cell_errors: Callable[[list[CellError]], None] | None = None
+    ) -> str:
         """Render a .py blog post to static markdown (reuses the page path)."""
         needs_pep723 = self.book.dependencies.auto_pep723
         with _maybe_stage_with_pep723(
             src, self.book.dependencies, enabled=needs_pep723, wasm_bootstrap=False
         ) as staged:
-            return _render_marimo(staged or src, self.book, sandbox=False)
+            return _render_marimo(
+                staged or src, self.book, sandbox=False, on_cell_errors=on_cell_errors
+            )
 
     def _stage_blog(self, docs_dir: Path, report: BuildReport) -> None:
         """Render and stage blog posts + index + merged .authors.yml."""
@@ -893,7 +938,15 @@ class Preprocessor:
         for src in posts:
             meta = resolve_meta(parse_post_header(src), src, default_author=default_author)
             if src.suffix == ".py":
-                body = self._render_notebook_body(src)
+                # Blog posts are never strict-fatal in v1 — warn only.
+                def _on_post_cell_errors(cell_errors: list[CellError], *, _src: Path = src) -> None:
+                    for e in cell_errors:
+                        report.warnings.append(
+                            f"{_src.name}: cell {e.cell_index} raised "
+                            f"{e.ename}: {e.evalue} (traceback published to post)"
+                        )
+
+                body = self._render_notebook_body(src, on_cell_errors=_on_post_cell_errors)
                 if meta.title == src.stem:
                     h1 = _first_markdown_heading(body)
                     if h1:
@@ -999,6 +1052,7 @@ def stage_page(
     md_basenames: set[str] | None = None,
     sandbox: bool = False,
     index_source: Path | None = None,
+    on_cell_errors: Callable[[list[CellError]], None] | None = None,
 ) -> Path:
     """Render a single TOC entry into ``docs_dir`` and return the output path."""
     src_abs = (book_dir / entry.file).resolve()
@@ -1032,7 +1086,9 @@ def stage_page(
                 body = render_wasm_page(src_abs, staged_source_path=staged)
                 apply_rewrites = False
             else:
-                body = _render_marimo(staged or src_abs, book, sandbox=sandbox)
+                body = _render_marimo(
+                    staged or src_abs, book, sandbox=sandbox, on_cell_errors=on_cell_errors
+                )
                 apply_rewrites = True
     elif src_abs.suffix == ".md":
         body = _render_markdown(src_abs)
@@ -1086,7 +1142,14 @@ def _finalize_page(
     return dst
 
 
-def render_py_body(book: Book, book_dir: Path, entry: FileEntry, *, sandbox: bool = False) -> str:
+def render_py_body(
+    book: Book,
+    book_dir: Path,
+    entry: FileEntry,
+    *,
+    sandbox: bool = False,
+    on_cell_errors: Callable[[list[CellError]], None] | None = None,
+) -> str:
     """Execute a ``.py`` entry and return its rendered body (pre-finalize).
 
     This is the expensive, source-dependent output that ``mode: cached``
@@ -1103,16 +1166,28 @@ def render_py_body(book: Book, book_dir: Path, entry: FileEntry, *, sandbox: boo
         enabled=book.dependencies.auto_pep723,
         wasm_bootstrap=False,
     ) as staged:
-        return _render_marimo(staged or src_abs, book, sandbox=sandbox)
+        return _render_marimo(
+            staged or src_abs, book, sandbox=sandbox, on_cell_errors=on_cell_errors
+        )
 
 
-def _render_marimo(src: Path, book: Book, *, sandbox: bool = False) -> str:
+def _render_marimo(
+    src: Path,
+    book: Book,
+    *,
+    sandbox: bool = False,
+    on_cell_errors: Callable[[list[CellError]], None] | None = None,
+) -> str:
     exp = export_notebook(
         src,
         sandbox=sandbox,
         suppress_warnings=book.defaults.suppress_warnings,
         timeout=book.defaults.execution_timeout,
     )
+    if on_cell_errors is not None:
+        cell_errors = collect_cell_errors(exp)
+        if cell_errors:
+            on_cell_errors(cell_errors)
     return cells_to_markdown(
         exp,
         hide_first_code_cell=book.defaults.hide_first_code_cell,

--- a/src/marimo_book/rendered_store.py
+++ b/src/marimo_book/rendered_store.py
@@ -104,7 +104,15 @@ class RenderedStore:
 
     # --- write side (`marimo-book render`) -----------------------------------
 
-    def write(self, src_rel: str, src_abs: Path, body: str, *, body_sig: str | None = None) -> None:
+    def write(
+        self,
+        src_rel: str,
+        src_abs: Path,
+        body: str,
+        *,
+        body_sig: str | None = None,
+        cell_errors: list[dict] | None = None,
+    ) -> None:
         """Persist a freshly rendered ``body`` and record its source hash.
 
         The body file mirrors the source path with a ``.md`` suffix so the
@@ -112,6 +120,8 @@ class RenderedStore:
         page maps to ``index.md`` in the built site. ``body_sig`` records the
         render-affecting config + tool version so a later build can detect a
         stale artifact even when the source bytes are unchanged.
+        ``cell_errors`` records any raising cells so a later ``build --strict``
+        can fail on a committed traceback without executing anything.
         """
         body_rel = Path(src_rel).with_suffix(".md").as_posix()
         body_abs = self.root / body_rel
@@ -123,8 +133,20 @@ class RenderedStore:
             "body_sig": body_sig,
             "rendered_at": datetime.now(UTC).isoformat(timespec="seconds"),
             "marimo_book_version": _tool_version(),
+            "cell_errors": cell_errors or [],
         }
         self.dirty = True
+
+    def recorded_cell_errors(self, src_rel: str) -> list[dict]:
+        """Raising cells captured at render time.
+
+        Entries committed before this key existed return ``[]`` — they are
+        grandfathered rather than schema-bumped, because a bump would mark
+        every committed body stale and force re-executing heavy notebooks.
+        """
+        entry = self.entries.get(src_rel) or {}
+        raw = entry.get("cell_errors")
+        return raw if isinstance(raw, list) else []
 
     def save(self) -> None:
         if not self.dirty and self.manifest_path.exists():

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -61,6 +61,9 @@ class ExportedNotebook:
 class CellError:
     """A cell whose execution raised — parsed from ipynb ``error`` outputs."""
 
+    # 1-based ordinal among the notebook's *code* cells (the exported ipynb
+    # interleaves markdown cells, whose positions would make the number
+    # meaningless to the author looking at their ``.py``).
     cell_index: int
     ename: str
     evalue: str
@@ -76,12 +79,16 @@ def collect_cell_errors(exported: ExportedNotebook) -> list[CellError]:
     (``--strict``) or just a warning.
     """
     errors: list[CellError] = []
-    for idx, cell in enumerate(exported.cells):
+    code_ordinal = 0
+    for cell in exported.cells:
         if cell.get("cell_type") != "code":
             continue
+        code_ordinal += 1
         for out in cell.get("outputs", []) or []:
             if out.get("output_type") == "error":
-                errors.append(CellError(idx, out.get("ename", "Error"), out.get("evalue", "")))
+                errors.append(
+                    CellError(code_ordinal, out.get("ename", "Error"), out.get("evalue", ""))
+                )
     return errors
 
 

--- a/src/marimo_book/transforms/marimo_export.py
+++ b/src/marimo_book/transforms/marimo_export.py
@@ -57,6 +57,34 @@ class ExportedNotebook:
     metadata: dict
 
 
+@dataclass
+class CellError:
+    """A cell whose execution raised — parsed from ipynb ``error`` outputs."""
+
+    cell_index: int
+    ename: str
+    evalue: str
+
+
+def collect_cell_errors(exported: ExportedNotebook) -> list[CellError]:
+    """Return every ``output_type: error`` in the exported notebook.
+
+    marimo exits nonzero when cells fail but still writes a valid ipynb
+    with the traceback as an error output; :func:`export_notebook` accepts
+    that case so the page can render the failure visibly. This helper lets
+    the build decide whether a visible traceback is also a build failure
+    (``--strict``) or just a warning.
+    """
+    errors: list[CellError] = []
+    for idx, cell in enumerate(exported.cells):
+        if cell.get("cell_type") != "code":
+            continue
+        for out in cell.get("outputs", []) or []:
+            if out.get("output_type") == "error":
+                errors.append(CellError(idx, out.get("ename", "Error"), out.get("evalue", "")))
+    return errors
+
+
 def export_notebook(
     py_path: Path,
     *,

--- a/src/marimo_book/transforms/precompute.py
+++ b/src/marimo_book/transforms/precompute.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 from .marimo_export import (
+    DEFAULT_EXPORT_TIMEOUT,
     cells_to_markdown_segments,
     export_notebook,
     export_notebook_with_overrides,
@@ -566,7 +567,7 @@ def precompute_page(
     max_combinations: int,
     sandbox: bool = False,
     suppress_warnings: bool = False,
-    timeout: float | None = None,
+    timeout: float | None = DEFAULT_EXPORT_TIMEOUT,
 ) -> PrecomputeResult:
     """Re-export a notebook once per (widget, value), return the staged body.
 

--- a/src/marimo_book/transforms/wasm.py
+++ b/src/marimo_book/transforms/wasm.py
@@ -98,6 +98,7 @@ def render_wasm_page(
     *,
     display_code: bool = False,
     staged_source_path: Path | None = None,
+    timeout: float | None = None,
 ) -> str:
     """Render a marimo notebook as a WASM-interactive page body.
 
@@ -123,7 +124,17 @@ def render_wasm_page(
     """
     target = staged_source_path or py_path
     gen = MarimoIslandGenerator.from_file(str(target), display_code=display_code)
-    asyncio.run(gen.build())
+    # ``gen.build()`` executes the notebook in-process (no subprocess), so it
+    # doesn't get export_notebook's timeout for free — bound it here so a
+    # hung wasm notebook can't stall build/serve/CI.
+    try:
+        asyncio.run(asyncio.wait_for(gen.build(), timeout))
+    except TimeoutError as exc:
+        raise RuntimeError(
+            f"wasm render timed out after {timeout:g}s for {py_path}. "
+            "Raise defaults.execution_timeout in book.yml (or set it to null "
+            "to disable) if this notebook legitimately runs longer."
+        ) from exc
     head = gen.render_head()
     # ``include_init_island=False`` skips marimo's static "Initializing..."
     # spinner. The bundle is supposed to hide that placeholder once cells

--- a/tests/fixtures/error_notebook.py
+++ b/tests/fixtures/error_notebook.py
@@ -1,0 +1,12 @@
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    raise ValueError("boom")
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/test_cached_render.py
+++ b/tests/test_cached_render.py
@@ -280,3 +280,44 @@ def test_build_cached_stale_under_strict_errors_without_executing(tmp_path: Path
     assert any("refusing to execute under --strict" in e for e in report.errors)
     assert report.pages_cached == 0
     assert report.pages_rendered == 1  # only the markdown index rendered
+
+
+# --- cell errors surfaced by `marimo-book render` ---------------------------
+
+
+def test_render_cached_warns_on_cell_error(tmp_path: Path) -> None:
+    content = tmp_path / "content"
+    content.mkdir(parents=True)
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    shutil.copy(FIXTURES / "error_notebook.py", content / "err.py")
+    book = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/err.py", "mode": "cached"},
+            ],
+        }
+    )
+    report = Preprocessor(book, book_dir=tmp_path).render_cached()
+    assert report.ok  # author-facing warning, never fatal
+    assert any("ValueError: boom" in w for w in report.warnings)
+
+
+def test_render_cached_allow_errors_silences(tmp_path: Path) -> None:
+    content = tmp_path / "content"
+    content.mkdir(parents=True)
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    shutil.copy(FIXTURES / "error_notebook.py", content / "err.py")
+    book = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/err.py", "mode": "cached", "allow_errors": True},
+            ],
+        }
+    )
+    report = Preprocessor(book, book_dir=tmp_path).render_cached()
+    assert report.ok
+    assert not any("boom" in w for w in report.warnings)

--- a/tests/test_cached_render.py
+++ b/tests/test_cached_render.py
@@ -321,3 +321,30 @@ def test_render_cached_allow_errors_silences(tmp_path: Path) -> None:
     report = Preprocessor(book, book_dir=tmp_path).render_cached()
     assert report.ok
     assert not any("boom" in w for w in report.warnings)
+
+
+def test_cached_page_with_committed_cell_error_fails_strict_build(tmp_path: Path) -> None:
+    """render commits the traceback body AND the cell-error record; a later
+    strict build must fail from the record without executing anything."""
+    content = tmp_path / "content"
+    content.mkdir(parents=True)
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    shutil.copy(FIXTURES / "error_notebook.py", content / "err.py")
+    book = Book.model_validate(
+        {
+            "title": "T",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/err.py", "mode": "cached"},
+            ],
+        }
+    )
+    pre = Preprocessor(book, book_dir=tmp_path)
+    assert pre.render_cached().ok  # warns, commits _rendered/
+
+    report = Preprocessor(book, book_dir=tmp_path).build(
+        out_dir=tmp_path / "_site_src", strict=True
+    )
+    assert report.pages_cached > 0  # sourced from the committed artifact
+    assert not report.ok
+    assert any("ValueError: boom" in e for e in report.errors)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,3 +220,14 @@ def test_execution_timeout_default_and_override(tmp_path: Path) -> None:
         )
     )
     assert load_book(book_yml).defaults.execution_timeout is None
+
+
+def test_file_entry_allow_errors_flag(tmp_path: Path) -> None:
+    book_yml = tmp_path / "book.yml"
+    book_yml.write_text(
+        yaml.safe_dump({"title": "T", "toc": [{"file": "a.py", "allow_errors": True}]})
+    )
+    assert load_book(book_yml).toc[0].allow_errors is True
+
+    book_yml.write_text(yaml.safe_dump({"title": "T", "toc": [{"file": "a.py"}]}))
+    assert load_book(book_yml).toc[0].allow_errors is False

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -439,7 +439,7 @@ def test_stage_page_routes_wasm_through_staged_path(tmp_path: Path) -> None:
     )
     captured: dict[str, str] = {}
 
-    def fake_render(py_path, *, display_code=False, staged_source_path=None):
+    def fake_render(py_path, *, display_code=False, staged_source_path=None, timeout=None):
         # Capture the staged source content while the tempdir still exists.
         assert staged_source_path is not None, "WASM path must receive a staged source"
         captured["content"] = staged_source_path.read_text()
@@ -662,3 +662,32 @@ def test_cell_error_allow_errors_silences(tmp_path: Path) -> None:
     )
     assert report.ok
     assert not any("boom" in w for w in report.warnings)
+
+
+def test_cell_error_strict_verdict_survives_cache_hit(tmp_path: Path) -> None:
+    """A non-strict (warn) build records the cache; the next strict build hits
+    the cache without re-exporting — it must still fail from the recorded
+    errors, not silently pass because the export was skipped."""
+    book = _error_book(tmp_path)
+
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.ok and report.pages_rendered > 0  # warm the cache, warning only
+
+    report = Preprocessor(book, book_dir=tmp_path).build(
+        out_dir=tmp_path / "_site_src", strict=True
+    )
+    assert report.pages_cached > 0  # exercised the cache-hit path, not a re-render
+    assert not report.ok
+    assert any("ValueError: boom" in e for e in report.errors)
+
+
+def test_execution_timeout_change_does_not_invalidate_signatures(tmp_path: Path) -> None:
+    """The timeout can abort a render but never change its output, so tuning it
+    must not invalidate the build cache or committed _rendered/ bodies."""
+    from marimo_book.preprocessor import _book_signature, _render_body_signature
+
+    base = {"title": "T", "toc": [{"file": "a.md"}]}
+    b1 = Book.model_validate(base)
+    b2 = Book.model_validate({**base, "defaults": {"execution_timeout": None}})
+    assert _render_body_signature(b1) == _render_body_signature(b2)
+    assert _book_signature(b1) == _book_signature(b2)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -483,7 +483,7 @@ def test_stage_page_auto_pep723_static_mode_skips_bootstrap(tmp_path: Path) -> N
     )
     captured: dict[str, str] = {}
 
-    def fake_render_marimo(src, book_arg, *, sandbox=False):
+    def fake_render_marimo(src, book_arg, *, sandbox=False, on_cell_errors=None):
         # Read content while the staged tempdir is still alive (it gets
         # torn down on context exit, before the assertions below).
         captured["content"] = Path(src).read_text(encoding="utf-8")
@@ -513,7 +513,7 @@ def test_stage_page_static_mode_skips_staging_by_default(tmp_path: Path) -> None
     book = Book.model_validate({"title": "T", "toc": [{"file": "content/nb.py"}]})
     captured = {"args": None}
 
-    def fake_render(src, book_arg, *, sandbox=False):
+    def fake_render(src, book_arg, *, sandbox=False, on_cell_errors=None):
         captured["args"] = src
         return "<!-- mocked -->"
 
@@ -623,3 +623,42 @@ def test_on_progress_reports_notebook_renders(tmp_path: Path) -> None:
 
     assert report.ok
     assert any("[1/1] content/nb.py (cache hit)" in m for m in messages)
+
+
+# --- cell-error strictness ----------------------------------------------------
+
+
+def _error_book(tmp_path: Path, *, allow_errors: bool = False) -> Book:
+    _minimal_book(tmp_path)
+    shutil.copy(FIXTURES / "error_notebook.py", tmp_path / "content" / "err.py")
+    entry: dict = {"file": "content/err.py"}
+    if allow_errors:
+        entry["allow_errors"] = True
+    return Book.model_validate({"title": "Test", "toc": [{"file": "content/intro.md"}, entry]})
+
+
+def test_cell_error_warns_on_default_build(tmp_path: Path) -> None:
+    book = _error_book(tmp_path)
+    report = Preprocessor(book, book_dir=tmp_path).build(out_dir=tmp_path / "_site_src")
+    assert report.ok  # non-strict: warn, don't fail
+    assert any("cell" in w and "ValueError: boom" in w for w in report.warnings)
+
+
+def test_cell_error_fails_strict_build(tmp_path: Path) -> None:
+    book = _error_book(tmp_path)
+    report = Preprocessor(book, book_dir=tmp_path).build(
+        out_dir=tmp_path / "_site_src", strict=True
+    )
+    assert not report.ok
+    assert any("ValueError: boom" in e for e in report.errors)
+    # The page still stages — strictness changes the verdict, not the output.
+    assert (tmp_path / "_site_src" / "docs" / "err.md").exists()
+
+
+def test_cell_error_allow_errors_silences(tmp_path: Path) -> None:
+    book = _error_book(tmp_path, allow_errors=True)
+    report = Preprocessor(book, book_dir=tmp_path).build(
+        out_dir=tmp_path / "_site_src", strict=True
+    )
+    assert report.ok
+    assert not any("boom" in w for w in report.warnings)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -563,3 +563,23 @@ def test_export_notebook_timeout_raises_actionable_error(monkeypatch, tmp_path: 
     monkeypatch.setattr(marimo_export.subprocess, "run", fake_run)
     with pytest.raises(RuntimeError, match="timed out after 1s"):
         marimo_export.export_notebook(nb, timeout=1)
+
+
+# --- cell-error collection ----------------------------------------------------
+
+
+def test_collect_cell_errors_finds_raising_cell() -> None:
+    from marimo_book.transforms.marimo_export import collect_cell_errors
+
+    exp = export_notebook(FIXTURES / "error_notebook.py")
+    errors = collect_cell_errors(exp)
+    assert len(errors) == 1
+    assert errors[0].ename == "ValueError"
+    assert errors[0].evalue == "boom"
+
+
+def test_collect_cell_errors_empty_for_clean_notebook() -> None:
+    from marimo_book.transforms.marimo_export import collect_cell_errors
+
+    exp = export_notebook(FIXTURES / "simple_notebook.py")
+    assert collect_cell_errors(exp) == []


### PR DESCRIPTION
> Stacked on #66 — GitHub will retarget this to `main` automatically when #66 merges.

## Summary
A notebook cell that raises at runtime renders its traceback into the published page (`<pre class="marimo-error">`) — useful while authoring, but previously **CI stayed green** because mkdocs `--strict` only validates nav/links. Broken notebooks shipped tracebacks to production silently.

- `collect_cell_errors()` parses `output_type: "error"` cells from the exported ipynb
- `build --strict`: each raising cell lands in `report.errors` → build fails (the page still stages; strictness changes the verdict, not the output)
- Non-strict builds, blog posts, and `marimo-book render` warn (render's warning notes the traceback would be committed to `_rendered/`)
- New TOC flag `allow_errors: true` opts out per entry, for lessons that intentionally demonstrate exceptions

## Proof it works
Enabling this immediately caught a real case: building this repo's own docs without `drawdata`/`anywidget` installed (CI installs them explicitly) previously produced pages full of `ModuleNotFoundError` tracebacks with a green build — now `build --strict` fails with `content/widgets.py: cell 2 raised ...`.

## Test plan
- 7 new tests: error-output parsing (raising + clean fixtures), `allow_errors` schema, warn-on-default-build, fail-on-strict (incl. page-still-stages), allow_errors-silences, render-cached warn + silence; suite now 306 passing
- `ruff check` + `ruff format --check` clean; strict docs build green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEsxCZ7dPygmxHWmu4PbxF