### PR TITLE
feat: real marimo-book check — build-free validation with exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`marimo-book check` is now a real doctor** (was a stub). In under a
+  second, with no notebook execution: missing TOC files, missing
+  logo/favicon/api_docs/blog paths, uninstalled extras for enabled features
+  (with the exact pip command), stale `mode: cached` artifacts, duplicate
+  staged outputs, inert config knobs (`bibliography:` until it ships,
+  reserved launch-button flags), buttons-without-repo, empty sections, and
+  broken relative links in `.md` sources (code fences/spans excluded).
+  Errors exit 1; `--strict` promotes warnings for CI.
 - **Serve/rebuild speed: the transient cache now stores pre-finalize bodies**
   (cache schema v3). Launch buttons and link rewrites are re-applied on every
   build, so TOC, title, `repo`, and `launch_buttons` edits no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ If a PR introduces a new optional extra (like `[autorefs]`), update
 both `.github/workflows/ci.yml` and `.github/workflows/docs.yml` to
 install it (the docs job needs every extra the docs site uses).
 
+`marimo-book check` (build-free doctor) lives in `src/marimo_book/checks.py`.
+Keep it fast and side-effect-free: no notebook execution, no subprocesses,
+no network. When adding a feature flag with a new extra, add its probe to
+`_FEATURE_EXTRAS` there so `check` catches the missing install.
+
 ## Build strictness and execution bounds (since 0.1.27)
 
 - **`build --strict` fails when a notebook cell raises.** The traceback

--- a/src/marimo_book/checks.py
+++ b/src/marimo_book/checks.py
@@ -1,0 +1,219 @@
+"""Build-free validations behind ``marimo-book check``.
+
+The point is speed and honesty: catch everything that would fail (or
+silently do nothing) during a real build, in under a second, with no
+notebook execution, no subprocesses, and no network. ``build --strict``
+remains the authority on rendered output; this is the pre-flight.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .config import Book, FileEntry, SectionEntry
+from .preprocessor import _doc_relpath_for, _iter_file_entries, _render_body_signature
+from .rendered_store import RenderedStore
+
+_SUPPORTED_SUFFIXES = {".md", ".py"}
+
+# Enabled-feature → (probe module, extra name). The probe is a module the
+# extra installs; find_spec is cheap and import-free.
+_FEATURE_EXTRAS: tuple[tuple[str, str, str], ...] = (
+    ("social_cards", "cairosvg", "social"),
+    ("pdf_export", "mkdocs_with_pdf", "pdf"),
+    ("check_external_links", "mkdocs_htmlproofer_plugin", "linkcheck"),
+    ("api_docs", "mkdocstrings", "api"),
+    ("blog_rss", "mkdocs_rss_plugin", "blog"),
+)
+
+# Relative markdown link targets: `[text](target)` — captures the target up
+# to the first `)`, `#` or whitespace so anchors/titles don't pollute it.
+_MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)#\s]+)[^)]*\)")
+
+
+@dataclass
+class CheckReport:
+    """Outcome of ``run_checks`` — printable, exit-code-ready."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def run_checks(book: Book, book_dir: Path) -> CheckReport:
+    """Validate a loaded book against its directory. Never executes code."""
+    book_dir = Path(book_dir).resolve()
+    report = CheckReport()
+    entries = _iter_file_entries(book.toc)
+
+    _check_toc_files(book, book_dir, entries, report)
+    _check_asset_paths(book, book_dir, report)
+    _check_extras(book, report)
+    _check_cached_freshness(book, book_dir, entries, report)
+    _check_duplicate_outputs(entries, report)
+    _check_inert_knobs(book, report)
+    _check_empty_sections(book.toc, report)
+    _check_internal_links(book_dir, entries, report)
+    return report
+
+
+# --- errors -------------------------------------------------------------------
+
+
+def _check_toc_files(
+    book: Book, book_dir: Path, entries: list[FileEntry], report: CheckReport
+) -> None:
+    for entry in entries:
+        src = book_dir / entry.file
+        if not src.exists():
+            report.errors.append(f"{entry.file}: TOC references a missing file")
+        elif src.suffix not in _SUPPORTED_SUFFIXES:
+            report.errors.append(
+                f"{entry.file}: unsupported file type (TOC entries must be .md or .py)"
+            )
+
+
+def _check_asset_paths(book: Book, book_dir: Path, report: CheckReport) -> None:
+    for label, value in (("logo", book.logo), ("favicon", book.favicon)):
+        if value is not None and not (book_dir / value).exists():
+            report.errors.append(f"{label}: file not found: {value}")
+    if book.api_docs.enabled:
+        for p in book.api_docs.paths:
+            if not (book_dir / p).resolve().exists():
+                report.errors.append(f"api_docs.paths: directory not found: {p}")
+    if book.blog.enabled and not (book_dir / book.blog.dir).exists():
+        report.errors.append(f"blog: source directory not found: {book.blog.dir}/")
+
+
+def _check_extras(book: Book, report: CheckReport) -> None:
+    enabled = {
+        "social_cards": book.social_cards,
+        "pdf_export": book.pdf_export,
+        "check_external_links": book.check_external_links,
+        "api_docs": book.api_docs.enabled,
+        "blog_rss": book.blog.enabled and book.blog.rss,
+    }
+    labels = {"blog_rss": "blog.rss"}
+    for feature, module, extra in _FEATURE_EXTRAS:
+        if enabled[feature] and not _module_available(module):
+            label = labels.get(feature, f"{feature}: true")
+            report.errors.append(
+                f"{label} needs the [{extra}] extra "
+                f"(pip install 'marimo-book[{extra}]')"
+            )
+
+
+def _check_cached_freshness(
+    book: Book, book_dir: Path, entries: list[FileEntry], report: CheckReport
+) -> None:
+    cached = [
+        e
+        for e in entries
+        if e.file.suffix == ".py" and e.effective_mode(book.defaults.mode) == "cached"
+    ]
+    if not cached:
+        return
+    store = RenderedStore(book_dir)
+    body_sig = _render_body_signature(book)
+    for entry in cached:
+        src_abs = (book_dir / entry.file).resolve()
+        if not src_abs.exists():
+            continue  # already an error from _check_toc_files
+        if not store.is_fresh(str(entry.file), src_abs, body_sig=body_sig):
+            reason = store.reason_stale(str(entry.file), src_abs, body_sig=body_sig)
+            report.errors.append(
+                f"{entry.file}: mode=cached but {reason}; "
+                f"run `marimo-book render` and commit _rendered/"
+            )
+
+
+def _check_duplicate_outputs(entries: list[FileEntry], report: CheckReport) -> None:
+    # Mirrors the build's staging rule: the first entry becomes index.md.
+    index_source = Path(entries[0].file) if entries else None
+    seen: dict[str, Path] = {}
+    for entry in entries:
+        out = _doc_relpath_for(entry.file, index_source=index_source).as_posix()
+        if out in seen:
+            report.errors.append(
+                f"{entry.file}: stages to '{out}', which {seen[out]} also stages to — "
+                f"one page would silently overwrite the other"
+            )
+        else:
+            seen[out] = entry.file
+
+
+# --- warnings -------------------------------------------------------------------
+
+
+def _check_inert_knobs(book: Book, report: CheckReport) -> None:
+    if book.bibliography.files:
+        report.warnings.append(
+            "bibliography: is configured but not implemented yet — "
+            "citations will not render"
+        )
+    for name in ("binder", "colab", "wasm"):
+        if getattr(book.launch_buttons, name, False):
+            report.warnings.append(
+                f"launch_buttons.{name}: true is reserved but not implemented — "
+                f"no button will render"
+            )
+    any_button = book.launch_buttons.molab or book.launch_buttons.github
+    if any_button and not book.repo:
+        report.warnings.append(
+            "launch_buttons are enabled but repo: is unset — the button row renders empty"
+        )
+
+
+def _check_empty_sections(toc: list, report: CheckReport) -> None:
+    for entry in toc:
+        if isinstance(entry, SectionEntry):
+            if not entry.children:
+                report.warnings.append(
+                    f"section '{entry.section}' has no children and will not render"
+                )
+            else:
+                _check_empty_sections(entry.children, report)
+
+
+def _check_internal_links(
+    book_dir: Path, entries: list[FileEntry], report: CheckReport
+) -> None:
+    """Static pass over .md sources for broken relative links.
+
+    A relative target is fine if it exists on disk next to the source, or if
+    its basename matches another TOC page (the link-rewrite convention maps
+    ``page.md`` links to whichever entry stages under that name). Notebook
+    prose is skipped — it needs a render, which ``build --strict`` covers.
+    """
+    md_basenames = {
+        entry.file.with_suffix("").name for entry in entries if entry.file.suffix == ".md"
+    } | {entry.file.with_suffix("").name for entry in entries if entry.file.suffix == ".py"}
+    for entry in entries:
+        src = book_dir / entry.file
+        if src.suffix != ".md" or not src.exists():
+            continue
+        text = src.read_text(encoding="utf-8")
+        for match in _MD_LINK_RE.finditer(text):
+            target = match.group(1)
+            if "://" in target or target.startswith(("mailto:", "/", "data:")):
+                continue
+            if (src.parent / target).exists():
+                continue
+            if Path(target).suffix in {".md", ".py", ".ipynb", ""}:
+                stem = Path(target).with_suffix("").name
+                if stem in md_basenames:
+                    continue
+            report.warnings.append(f"{entry.file}: broken relative link '{target}'")

--- a/src/marimo_book/checks.py
+++ b/src/marimo_book/checks.py
@@ -33,6 +33,11 @@ _FEATURE_EXTRAS: tuple[tuple[str, str, str], ...] = (
 # to the first `)`, `#` or whitespace so anchors/titles don't pollute it.
 _MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)#\s]+)[^)]*\)")
 
+# Regions whose "links" are examples, not links: fenced blocks and inline
+# code spans. Stripped before the link scan.
+_CODE_FENCE_RE = re.compile(r"^(```|~~~).*?^\1\s*$", re.MULTILINE | re.DOTALL)
+_CODE_SPAN_RE = re.compile(r"`[^`\n]*`")
+
 
 @dataclass
 class CheckReport:
@@ -66,7 +71,7 @@ def run_checks(book: Book, book_dir: Path) -> CheckReport:
     _check_duplicate_outputs(entries, report)
     _check_inert_knobs(book, report)
     _check_empty_sections(book.toc, report)
-    _check_internal_links(book_dir, entries, report)
+    _check_internal_links(book, book_dir, entries, report)
     return report
 
 
@@ -111,8 +116,7 @@ def _check_extras(book: Book, report: CheckReport) -> None:
         if enabled[feature] and not _module_available(module):
             label = labels.get(feature, f"{feature}: true")
             report.errors.append(
-                f"{label} needs the [{extra}] extra "
-                f"(pip install 'marimo-book[{extra}]')"
+                f"{label} needs the [{extra}] extra (pip install 'marimo-book[{extra}]')"
             )
 
 
@@ -161,8 +165,7 @@ def _check_duplicate_outputs(entries: list[FileEntry], report: CheckReport) -> N
 def _check_inert_knobs(book: Book, report: CheckReport) -> None:
     if book.bibliography.files:
         report.warnings.append(
-            "bibliography: is configured but not implemented yet — "
-            "citations will not render"
+            "bibliography: is configured but not implemented yet — citations will not render"
         )
     for name in ("binder", "colab", "wasm"):
         if getattr(book.launch_buttons, name, False):
@@ -189,7 +192,7 @@ def _check_empty_sections(toc: list, report: CheckReport) -> None:
 
 
 def _check_internal_links(
-    book_dir: Path, entries: list[FileEntry], report: CheckReport
+    book: Book, book_dir: Path, entries: list[FileEntry], report: CheckReport
 ) -> None:
     """Static pass over .md sources for broken relative links.
 
@@ -197,15 +200,19 @@ def _check_internal_links(
     its basename matches another TOC page (the link-rewrite convention maps
     ``page.md`` links to whichever entry stages under that name). Notebook
     prose is skipped — it needs a render, which ``build --strict`` covers.
+    Links inside fenced blocks / inline code are examples, not links.
     """
-    md_basenames = {
-        entry.file.with_suffix("").name for entry in entries if entry.file.suffix == ".md"
-    } | {entry.file.with_suffix("").name for entry in entries if entry.file.suffix == ".py"}
+    md_basenames = {entry.file.with_suffix("").name for entry in entries}
+    if book.include_changelog:
+        # Generated page: staged from CHANGELOG.md at build time.
+        md_basenames.add("changelog")
     for entry in entries:
         src = book_dir / entry.file
         if src.suffix != ".md" or not src.exists():
             continue
         text = src.read_text(encoding="utf-8")
+        text = _CODE_FENCE_RE.sub("", text)
+        text = _CODE_SPAN_RE.sub("", text)
         for match in _MD_LINK_RE.finditer(text):
             target = match.group(1)
             if "://" in target or target.startswith(("mailto:", "/", "data:")):

--- a/src/marimo_book/cli.py
+++ b/src/marimo_book/cli.py
@@ -506,14 +506,32 @@ def check(
     strict: bool = typer.Option(
         False,
         "--strict",
-        help="Fail on warnings.",
+        help="Exit nonzero on warnings too, not just errors (for CI).",
     ),
 ) -> None:
-    """Validate ``book.yml`` and linked content without building."""
+    """Validate ``book.yml`` and linked content without building.
+
+    Fast pre-flight (< 1 s, no notebook execution): missing TOC files,
+    missing asset paths, uninstalled extras for enabled features, stale
+    ``mode: cached`` artifacts, duplicate staged outputs, inert config
+    knobs, and broken relative links in ``.md`` sources. ``build --strict``
+    remains the authority on rendered output.
+    """
+    from .checks import run_checks
+
     book = _load_or_exit(book_file)
-    typer.echo(f"OK: loaded '{book.title}' with {_count_toc(book.toc)} TOC entries")
-    if strict:
-        typer.echo("[stub] --strict content checks not yet implemented")
+    report = run_checks(book, book_file.resolve().parent)
+    for err in report.errors:
+        typer.echo(f"  error: {err}", err=True)
+    for warn in report.warnings:
+        typer.echo(f"  warning: {warn}", err=True)
+
+    if report.errors or report.warnings:
+        typer.echo(f"{len(report.errors)} errors, {len(report.warnings)} warnings.")
+    if report.errors or (strict and report.warnings):
+        raise typer.Exit(code=1)
+    if not report.warnings:
+        typer.echo(f"All checks passed ({_count_toc(book.toc)} TOC entries).")
 
 
 @app.command("sync-deps")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -239,3 +239,22 @@ def test_broken_relative_link_warns_and_valid_ones_pass(tmp_path: Path) -> None:
     assert len(broken) == 2
     assert any("missing.md" in w for w in broken)
     assert any("images/gone.png" in w for w in broken)
+
+
+def test_links_in_code_fences_and_spans_are_ignored(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "include_changelog": True, "toc": [{"file": "content/a.md"}]},
+        files=["content/a.md"],
+    )
+    (tmp_path / "content" / "a.md").write_text(
+        "# A\n"
+        "```markdown\n[example](not-a-real-page.md)\n```\n"
+        "Use `[label](page.md)` syntax for cross-refs.\n"
+        "[changelog](changelog.md)\n",  # generated page — valid with the flag on
+        encoding="utf-8",
+    )
+    report = run_checks(book, tmp_path)
+    assert not any("broken relative link" in w for w in report.warnings)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,241 @@
+"""Tests for `marimo-book check`'s build-free validations (checks.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from marimo_book.config import Book, load_book
+
+
+def _book(tmp_path: Path, data: dict, *, files: list[str] | None = None) -> Book:
+    """Write book.yml + the given content files, return the loaded Book."""
+    content = tmp_path / "content"
+    content.mkdir(exist_ok=True)
+    for rel in files or []:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if rel.endswith(".py"):
+            p.write_text("import marimo\napp = marimo.App()\n", encoding="utf-8")
+        else:
+            p.write_text("# Page\n", encoding="utf-8")
+    book_yml = tmp_path / "book.yml"
+    book_yml.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return load_book(book_yml)
+
+
+# --- errors -------------------------------------------------------------------
+
+
+def test_missing_toc_file_is_error(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "toc": [{"file": "content/a.md"}, {"file": "content/gone.py"}]},
+        files=["content/a.md"],
+    )
+    report = run_checks(book, tmp_path)
+    assert not report.ok
+    assert any("content/gone.py" in e and "missing" in e for e in report.errors)
+
+
+def test_unsupported_suffix_is_error(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "toc": [{"file": "content/notes.txt"}]},
+        files=["content/notes.txt"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("notes.txt" in e and "unsupported" in e.lower() for e in report.errors)
+
+
+def test_missing_logo_and_favicon_are_errors(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {
+            "title": "T",
+            "logo": "images/logo.png",
+            "favicon": "images/favicon.ico",
+            "toc": [{"file": "content/a.md"}],
+        },
+        files=["content/a.md"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("logo" in e for e in report.errors)
+    assert any("favicon" in e for e in report.errors)
+
+
+def test_missing_extra_is_error(tmp_path: Path, monkeypatch) -> None:
+    from marimo_book import checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "social_cards": True, "toc": [{"file": "content/a.md"}]},
+        files=["content/a.md"],
+    )
+    monkeypatch.setattr(checks, "_module_available", lambda name: False)
+    report = checks.run_checks(book, tmp_path)
+    assert any("social_cards" in e and "[social]" in e for e in report.errors)
+
+
+def test_installed_extra_passes(tmp_path: Path, monkeypatch) -> None:
+    from marimo_book import checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "social_cards": True, "toc": [{"file": "content/a.md"}]},
+        files=["content/a.md"],
+    )
+    monkeypatch.setattr(checks, "_module_available", lambda name: True)
+    report = checks.run_checks(book, tmp_path)
+    assert not any("social_cards" in e for e in report.errors)
+
+
+def test_stale_cached_page_is_error(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "toc": [{"file": "content/nb.py", "mode": "cached"}]},
+        files=["content/nb.py"],
+    )
+    report = run_checks(book, tmp_path)  # nothing committed → stale
+    assert any("nb.py" in e and "marimo-book render" in e for e in report.errors)
+
+
+def test_fresh_cached_page_passes(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+    from marimo_book.preprocessor import _render_body_signature
+    from marimo_book.rendered_store import RenderedStore
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "toc": [{"file": "content/nb.py", "mode": "cached"}]},
+        files=["content/nb.py"],
+    )
+    store = RenderedStore(tmp_path)
+    store.write(
+        "content/nb.py",
+        tmp_path / "content" / "nb.py",
+        "BODY",
+        body_sig=_render_body_signature(book),
+    )
+    store.save()
+    report = run_checks(book, tmp_path)
+    assert not any("nb.py" in e for e in report.errors)
+
+
+# --- warnings -------------------------------------------------------------------
+
+
+def test_inert_bibliography_warns(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    (tmp_path / "refs.bib").write_text("@misc{k, title={T}}\n", encoding="utf-8")
+    book = _book(
+        tmp_path,
+        {
+            "title": "T",
+            "bibliography": {"files": ["refs.bib"]},
+            "toc": [{"file": "content/a.md"}],
+        },
+        files=["content/a.md"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("bibliography" in w and "not implemented" in w for w in report.warnings)
+
+
+def test_reserved_launch_button_flags_warn(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {
+            "title": "T",
+            "repo": "https://github.com/o/r",
+            "launch_buttons": {"binder": True},
+            "toc": [{"file": "content/a.md"}],
+        },
+        files=["content/a.md"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("launch_buttons.binder" in w for w in report.warnings)
+
+
+def test_buttons_without_repo_warn(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path, {"title": "T", "toc": [{"file": "content/a.md"}]}, files=["content/a.md"]
+    )
+    report = run_checks(book, tmp_path)
+    assert any("repo:" in w and "button row" in w for w in report.warnings)
+
+
+def test_empty_section_warns(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {
+            "title": "T",
+            "toc": [{"file": "content/a.md"}, {"section": "Soon", "children": None}],
+        },
+        files=["content/a.md"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("'Soon'" in w for w in report.warnings)
+
+
+def test_duplicate_staged_output_is_error(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    # intro.md occupies the first slot so neither colliding entry gets
+    # promoted to index.md; x.py and x.md then both stage to x.md.
+    book = _book(
+        tmp_path,
+        {
+            "title": "T",
+            "toc": [
+                {"file": "content/intro.md"},
+                {"file": "content/x.md"},
+                {"file": "content/x.py"},
+            ],
+        },
+        files=["content/intro.md", "content/x.md", "content/x.py"],
+    )
+    report = run_checks(book, tmp_path)
+    assert any("silently overwrite" in e for e in report.errors)
+
+
+def test_broken_relative_link_warns_and_valid_ones_pass(tmp_path: Path) -> None:
+    from marimo_book.checks import run_checks
+
+    book = _book(
+        tmp_path,
+        {"title": "T", "toc": [{"file": "content/a.md"}, {"file": "content/b.md"}]},
+        files=["content/b.md"],
+    )
+    (tmp_path / "content" / "images").mkdir()
+    (tmp_path / "content" / "images" / "fig.png").write_bytes(b"\x89PNG")
+    (tmp_path / "content" / "a.md").write_text(
+        "# A\n"
+        "[ok page](b.md)\n"
+        "[ok image](images/fig.png)\n"
+        "[external](https://example.org)\n"
+        "[anchor](#section)\n"
+        "[broken](missing.md)\n"
+        "[broken img](images/gone.png)\n",
+        encoding="utf-8",
+    )
+    report = run_checks(book, tmp_path)
+    broken = [w for w in report.warnings if "broken relative link" in w]
+    assert len(broken) == 2
+    assert any("missing.md" in w for w in broken)
+    assert any("images/gone.png" in w for w in broken)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -272,3 +272,47 @@ def test_new_post_respects_blog_dir_from_book_yml(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert (tmp_path / "news" / "posts" / "2026-06-04-hi.md").exists()
+
+
+# --- check --------------------------------------------------------------------
+
+
+def _write_book(tmp_path: Path, *, broken: bool = False) -> Path:
+    content = tmp_path / "content"
+    content.mkdir()
+    (content / "intro.md").write_text("# Intro\n", encoding="utf-8")
+    toc = "  - file: content/intro.md\n"
+    if broken:
+        toc += "  - file: content/missing.py\n"
+    book_yml = tmp_path / "book.yml"
+    book_yml.write_text(f"title: T\nrepo: https://github.com/o/r\ntoc:\n{toc}", encoding="utf-8")
+    return book_yml
+
+
+def test_check_passes_on_clean_book(runner: CliRunner, tmp_path: Path) -> None:
+    book_yml = _write_book(tmp_path)
+    result = runner.invoke(app, ["check", "-b", str(book_yml)])
+    assert result.exit_code == 0, result.output
+    assert "All checks passed" in result.output
+
+
+def test_check_fails_on_missing_file(runner: CliRunner, tmp_path: Path) -> None:
+    book_yml = _write_book(tmp_path, broken=True)
+    result = runner.invoke(app, ["check", "-b", str(book_yml)])
+    assert result.exit_code == 1
+    assert "missing" in result.output
+
+
+def test_check_strict_promotes_warnings(runner: CliRunner, tmp_path: Path) -> None:
+    content = tmp_path / "content"
+    content.mkdir()
+    (content / "intro.md").write_text("# Intro\n[dead](gone.md)\n", encoding="utf-8")
+    book_yml = tmp_path / "book.yml"
+    book_yml.write_text(
+        "title: T\nrepo: https://github.com/o/r\ntoc:\n  - file: content/intro.md\n",
+        encoding="utf-8",
+    )
+    assert runner.invoke(app, ["check", "-b", str(book_yml)]).exit_code == 0
+    result = runner.invoke(app, ["check", "-b", str(book_yml), "--strict"])
+    assert result.exit_code == 1
+    assert "broken relative link" in result.output


### PR DESCRIPTION
## Summary
`marimo-book check` was a stub (loaded book.yml, printed a count; `--strict` printed \"[stub]\"). It's now a real doctor that runs in <1 s with no notebook execution, no subprocesses, no network:

**Errors (exit 1):**
- TOC `file:` missing or unsupported suffix
- `logo`/`favicon`/`api_docs.paths`/`blog.dir` paths missing
- Enabled feature whose extra isn't installed (message includes the exact pip command): `social_cards`→cairosvg, `pdf_export`, `check_external_links`, `api_docs`, `blog.rss`
- `mode: cached` pages with stale/missing `_rendered/` artifacts (folds the freshness gate into the doctor)
- Two TOC entries staging to the same output file (silent overwrite)

**Warnings (exit 0, or 1 with `--strict`):**
- Inert config: `bibliography:` (until the native citations PR lands), reserved `launch_buttons.binder/colab/wasm`
- Launch buttons enabled with no `repo:` (empty button row)
- Empty TOC sections
- Broken relative links in `.md` sources — validated against the filesystem and TOC basenames, with code fences/inline spans stripped (docs *about* link syntax don't false-flag) and the generated `changelog.md` honored when `include_changelog` is on

Dogfooded: running it on this repo's own docs book initially flagged 6 links; all were examples inside code fences or the generated changelog target, which drove the fence/span-stripping design. Now passes clean.

## Test plan
- 14 new checks tests + 3 CLI tests (clean pass, error exit code, --strict promotion); suite at 338
- ruff clean, strict docs build green, live `check -b docs/book.yml` passes in ~0.3 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEsxCZ7dPygmxHWmu4PbxF