### PR TITLE
docs(changelog): date the 0.1.27 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.27] — 2026-07-02
 
 ### Added
 


### PR DESCRIPTION
One-line release prep per the standard flow: dates [Unreleased] → 0.1.27. Tag + PyPI publish follow via gh release create after merge.

0.1.27 ships: real \`marimo-book check\`, native citations, body-level transient cache (6.5× faster warm builds), cell-error strictness for \`build --strict\`, \`defaults.execution_timeout\`, theme polish (auto dark mode, prefetch, back-to-top), per-notebook build progress, and dependency hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEsxCZ7dPygmxHWmu4PbxF