### PR TITLE
feat: extra_css option in book.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `marimo-book` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`extra_css` in `book.yml`.** A list of stylesheets, relative to the book
+  root, copied into the staged tree and appended to mkdocs's `extra_css`
+  after marimo-book's own sheet, so author rules win. Lets a book restyle
+  rendered output — capping the height of a long `print()` block, say —
+  without injecting `<style>` tags into notebook sources. `emit_mkdocs_yml`
+  already accepted an `extra_css` argument and merged it; only the config
+  field and the staging step were missing. Paths must stay inside the book
+  root and cannot reuse a built-in stylesheet name; a declared file that
+  does not exist warns rather than failing the build.
+
 ## [0.1.30] — 2026-07-03
 
 ### Fixed

--- a/docs/content/book_yml.md
+++ b/docs/content/book_yml.md
@@ -133,6 +133,34 @@ Each author supports `name` (required), `orcid`, `affiliation`, and
 | `theme.palette.accent` | hex color | Material default | Highlights + active states |
 | `theme.font.text` | Google Font name | `Roboto` | Body font |
 | `theme.font.code` | Google Font name | `Roboto Mono` | Code font |
+| `extra_css` | list of paths | `[]` | Stylesheets relative to the book root, loaded after marimo-book's own |
+
+### Extra stylesheets
+
+`extra_css` restyles rendered output without touching notebook sources.
+Each file is copied into the staged tree and appended to mkdocs's
+`extra_css` **after** the built-in sheet, so your rules win. A declared
+file that does not exist is a build warning, not an error.
+
+```yaml
+extra_css:
+  - stylesheets/custom.css
+```
+
+A common use is capping the height of a long `print()` block, which
+renders as `pre.marimo-book-output-text`:
+
+```css
+pre.marimo-book-output-text {
+  max-height: 24rem;
+  overflow-y: auto;
+}
+```
+
+Paths must stay inside the book root, and cannot reuse a name
+marimo-book writes itself (`stylesheets/extra.css`,
+`stylesheets/logo_sidebar.css`) — that would replace the built-in sheet
+rather than layer on it.
 
 ### Launch buttons
 

--- a/src/marimo_book/config.py
+++ b/src/marimo_book/config.py
@@ -31,6 +31,11 @@ from pydantic import (
     model_validator,
 )
 
+# Stylesheets marimo-book writes into the staged tree itself. An ``extra_css``
+# entry may not claim one of these names, or it would replace the built-in
+# sheet instead of layering on top of it.
+RESERVED_STYLESHEETS = frozenset({"stylesheets/extra.css", "stylesheets/logo_sidebar.css"})
+
 # --- leaf models -------------------------------------------------------------
 
 
@@ -442,6 +447,16 @@ class Book(BaseModel):
     # OpenGraph URLs, sitemap.xml gets the right href, etc.
     url: str | None = None
 
+    # Extra stylesheets, relative to the book root, layered on top of
+    # marimo-book's own. They restyle rendered output without touching
+    # notebook sources — capping the height of a long stdout block, say.
+    # Each file is copied into the staged tree and appended to mkdocs's
+    # ``extra_css`` after the built-in sheet, so later rules win.
+    #
+    #   extra_css:
+    #     - stylesheets/custom.css
+    extra_css: list[Path] = Field(default_factory=list)
+
     # branding
     logo: Path | None = None
     favicon: Path | None = None
@@ -547,6 +562,22 @@ class Book(BaseModel):
         """Allow ``bibliography: [path1, path2]`` shorthand in YAML."""
         if isinstance(v, list):
             return {"files": v}
+        return v
+
+    @field_validator("extra_css")
+    @classmethod
+    def _check_extra_css(cls, v: list[Path]) -> list[Path]:
+        """Keep stylesheets inside the book and off the built-in names.
+
+        An absolute path or a ``..`` segment would copy from outside the
+        book root, and reusing a built-in name would silently replace
+        marimo-book's own stylesheet rather than layering on it.
+        """
+        for path in v:
+            if path.is_absolute() or ".." in path.parts:
+                raise ValueError(f"extra_css entries must be relative to the book root: {path}")
+            if path.as_posix() in RESERVED_STYLESHEETS:
+                raise ValueError(f"{path} is a built-in stylesheet name; use a different one")
         return v
 
 

--- a/src/marimo_book/preprocessor.py
+++ b/src/marimo_book/preprocessor.py
@@ -676,6 +676,7 @@ class Preprocessor:
 
         self._stage_assets(docs_dir, report)
         self._write_defaults(docs_dir)
+        extra_css = self._stage_extra_css(docs_dir, report)
 
         file_entries = _iter_file_entries(self.book.toc)
 
@@ -878,6 +879,7 @@ class Preprocessor:
             site_dir=site_dir,
             out_path=out_dir / "mkdocs.yml",
             nav=nav,
+            extra_css=extra_css or None,
             api_paths=api_paths or None,
         )
 
@@ -1275,6 +1277,26 @@ class Preprocessor:
                 assets_root / "logo_sidebar.css",
                 docs_dir / "stylesheets" / "logo_sidebar.css",
             )
+
+    def _stage_extra_css(self, docs_dir: Path, report: BuildReport) -> list[str]:
+        """Copy author stylesheets into the staged tree.
+
+        Returns the staged paths, which shell.py appends to mkdocs's
+        ``extra_css`` after the built-in sheet so author rules win. A
+        declared file that does not exist is a warning rather than an
+        error: the site is still buildable, just unstyled.
+        """
+        staged: list[str] = []
+        for relative in self.book.extra_css:
+            source = self.book_dir / relative
+            if not source.is_file():
+                report.warnings.append(f"extra_css: {relative} not found under {self.book_dir}")
+                continue
+            destination = docs_dir / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            staged.append(relative.as_posix())
+        return staged
 
 
 # --- TOC traversal ----------------------------------------------------------

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -947,3 +947,72 @@ def test_citations_render_and_bib_edits_apply_without_rerender(tmp_path: Path) -
     assert report.pages_cached == 1  # notebook untouched
     staged = (tmp_path / "_site_src" / "docs" / "index.md").read_text(encoding="utf-8")
     assert ">Doe, 2021</a>)" in staged  # .bib edit applied at finalize time
+
+
+# --- extra_css ----------------------------------------------------------------
+
+
+def _css_book(entries: list[str]) -> Book:
+    return Book.model_validate(
+        {
+            "title": "Test",
+            "extra_css": entries,
+            "toc": [{"file": "content/intro.md"}],
+        }
+    )
+
+
+def _staged_css(out_dir: Path) -> list[str]:
+    """The mkdocs extra_css list, with the cache-busting suffix stripped."""
+    mkdocs = yaml.safe_load((out_dir / "mkdocs.yml").read_text(encoding="utf-8"))
+    return [str(item).split("?")[0] for item in mkdocs["extra_css"]]
+
+
+def test_extra_css_is_staged_and_listed_after_the_builtin(tmp_path: Path) -> None:
+    _minimal_book(tmp_path)
+    (tmp_path / "stylesheets").mkdir()
+    (tmp_path / "stylesheets" / "custom.css").write_text(
+        "pre.marimo-book-output-text { max-height: 24rem; }\n", encoding="utf-8"
+    )
+    out_dir = tmp_path / "_site_src"
+
+    Preprocessor(_css_book(["stylesheets/custom.css"]), book_dir=tmp_path).build(out_dir=out_dir)
+
+    staged = out_dir / "docs" / "stylesheets" / "custom.css"
+    assert staged.exists(), "extra_css should copy the file into the staged tree"
+    assert "max-height" in staged.read_text(encoding="utf-8")
+
+    paths = _staged_css(out_dir)
+    assert paths.index("stylesheets/extra.css") < paths.index("stylesheets/custom.css"), (
+        f"author CSS must load after the built-in sheet so its rules win; got {paths}"
+    )
+
+
+def test_extra_css_absent_by_default(tmp_path: Path) -> None:
+    _minimal_book(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    Preprocessor(_css_book([]), book_dir=tmp_path).build(out_dir=out_dir)
+
+    assert _staged_css(out_dir) == ["stylesheets/extra.css"]
+
+
+def test_extra_css_missing_file_warns_without_failing(tmp_path: Path) -> None:
+    """A declared-but-absent sheet leaves the site buildable, just unstyled."""
+    _minimal_book(tmp_path)
+    out_dir = tmp_path / "_site_src"
+
+    report = Preprocessor(_css_book(["stylesheets/nope.css"]), book_dir=tmp_path).build(
+        out_dir=out_dir
+    )
+
+    assert any("nope.css" in w for w in report.warnings), report.warnings
+    assert "stylesheets/nope.css" not in _staged_css(out_dir)
+
+
+def test_extra_css_rejects_escaping_and_reserved_names() -> None:
+    import pytest
+
+    for bad in ("../secrets.css", "stylesheets/extra.css"):
+        with pytest.raises(ValueError):
+            _css_book([bad])


### PR DESCRIPTION
﻿## What

Adds an `extra_css` list to `book.yml`: stylesheets relative to the book
root, copied into the staged tree and appended to mkdocs's `extra_css`
after marimo-book's own sheet.

```yaml
extra_css:
  - stylesheets/custom.css
```

## Why

I hit this documenting a Python library whose notebooks print large
tables. The rendered `<pre class="marimo-book-output-text">` blocks run to
hundreds of lines, and there is currently no supported way to cap their
height:

```css
pre.marimo-book-output-text { max-height: 28rem; overflow-y: auto; }
```

`book.yml` has no CSS hook, every model is `extra="forbid"`, and
`_write_defaults` rewrites `stylesheets/extra.css` from package assets on
each build. The only workarounds are injecting `<style>` from a notebook
cell (styling logic in notebook sources, repeated per page) or patching the
installed package.

## Notes for review

Most of the plumbing already existed: `emit_mkdocs_yml` accepts
`extra_css`, `_build_config` merges it as `[*base_css, *extra_css]`, and
`_versioned()` cache-busts it. Only the config field and the staging step
were missing, so author sheets get the same cache-busting as built-ins for
free.

Behaviour choices, happy to change either:

- **A missing file warns rather than errors.** The site is still buildable,
  just unstyled. `--strict` still fails on it via the usual warning path.
- **Validation rejects absolute paths, `..` segments, and the two built-in
  stylesheet names.** Reusing `stylesheets/extra.css` would replace the
  built-in sheet rather than layer on it, which seemed worth catching at
  config-load time so `marimo-book check` surfaces it.

Docs added to `docs/content/book_yml.md` (Branding table + a short section
with the scrollable-output example). CHANGELOG under `[Unreleased]`.

## Testing

Four tests in `tests/test_preprocessor.py`: staging + ordering after the
built-in sheet, absent by default, missing-file warning, and validation
rejections.

`pytest` and `ruff check` / `ruff format --check` pass. Local runs were on
Windows, where 25 tests fail on `main` before this change too (chmod
semantics, `\` path separators), so I compared against a baseline run at
the base commit: 25 failed / 342 passed before, 25 failed / 346 passed
after — same failures, plus the four new tests.
